### PR TITLE
Make wealth trajectory chart collapsible

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1923,6 +1923,21 @@ export default function App() {
     });
   }, [inputs]);
 
+  const leverageEfficiencyData = useMemo(
+    () =>
+      leverageChartData.map((point) => {
+        const efficiencyValue =
+          Number.isFinite(point.irr) && Number.isFinite(point.propertyNetAfterTax)
+            ? point.irr * point.propertyNetAfterTax
+            : 0;
+        return {
+          ...point,
+          efficiency: efficiencyValue,
+        };
+      }),
+    [leverageChartData]
+  );
+
   const hasInterestSplitData = interestSplitChartData.some(
     (point) => Math.abs(point.interestPaid) > 1e-2 || Math.abs(point.principalPaid) > 1e-2
   );
@@ -4229,84 +4244,112 @@ export default function App() {
                     </p>
                     <div className="h-72 w-full">
                       {hasLeverageData ? (
-                        <ResponsiveContainer>
-                          <LineChart data={leverageChartData} margin={{ top: 10, right: 80, left: 0, bottom: 0 }}>
-                            <CartesianGrid strokeDasharray="3 3" />
-                            <XAxis
-                              dataKey="ltv"
-                              tickFormatter={(value) => formatPercent(value)}
-                              tick={{ fontSize: 11, fill: '#475569' }}
-                              domain={[0.1, 0.95]}
-                              type="number"
-                              ticks={LEVERAGE_LTV_OPTIONS}
-                            />
-                            <YAxis
-                              yAxisId="left"
-                              tickFormatter={(value) => formatPercent(value)}
-                              tick={{ fontSize: 11, fill: '#475569' }}
-                              width={90}
-                            />
-                            <YAxis
-                              yAxisId="right"
-                              orientation="right"
-                              tickFormatter={(value) => currency(value)}
-                              tick={{ fontSize: 11, fill: '#475569' }}
-                              width={120}
-                            />
-                            <Tooltip
-                              formatter={(value, name, { dataKey }) => {
-                                if (dataKey === 'propertyNetAfterTax') {
-                                  return [currency(value), name];
-                                }
-                                return [formatPercent(value), name];
-                              }}
-                              labelFormatter={(label) => `LTV ${formatPercent(label)}`}
-                            />
-                            <Legend
-                              content={(props) => (
-                                <ChartLegend
-                                  {...props}
-                                  activeSeries={leverageSeriesActive}
-                                  onToggle={toggleLeverageSeries}
-                                />
-                              )}
-                            />
-                            <RechartsLine
-                              type="monotone"
-                              dataKey="irr"
-                              name="IRR"
-                              yAxisId="left"
-                              stroke={SERIES_COLORS.irrSeries}
-                              strokeWidth={2}
-                              dot={{ r: 3 }}
-                              isAnimationActive={false}
-                              hide={!leverageSeriesActive.irr}
-                            />
-                            <RechartsLine
-                              type="monotone"
-                              dataKey="roi"
-                              name="Total ROI"
-                              yAxisId="left"
-                              stroke="#0ea5e9"
-                              strokeWidth={2}
-                              strokeDasharray="4 2"
-                              dot={{ r: 3 }}
-                              isAnimationActive={false}
-                              hide={!leverageSeriesActive.roi}
-                            />
-                            <RechartsLine
-                              type="monotone"
-                              dataKey="propertyNetAfterTax"
-                              name={propertyNetAfterTaxLabel}
-                              yAxisId="right"
-                              stroke={SERIES_COLORS.propertyNetAfterTax}
-                              strokeWidth={2}
-                              dot={{ r: 3 }}
-                              isAnimationActive={false}
-                              hide={!leverageSeriesActive.propertyNetAfterTax}
-                            />
-                          </LineChart>
-                        </ResponsiveContainer>
+                        <>
+                          <ResponsiveContainer>
+                            <LineChart data={leverageChartData} margin={{ top: 10, right: 80, left: 0, bottom: 0 }}>
+                              <CartesianGrid strokeDasharray="3 3" />
+                              <XAxis
+                                dataKey="ltv"
+                                tickFormatter={(value) => formatPercent(value)}
+                                tick={{ fontSize: 11, fill: '#475569' }}
+                                domain={[0.1, 0.95]}
+                                type="number"
+                                ticks={LEVERAGE_LTV_OPTIONS}
+                              />
+                              <YAxis
+                                yAxisId="left"
+                                tickFormatter={(value) => formatPercent(value)}
+                                tick={{ fontSize: 11, fill: '#475569' }}
+                                width={90}
+                              />
+                              <YAxis
+                                yAxisId="right"
+                                orientation="right"
+                                tickFormatter={(value) => currency(value)}
+                                tick={{ fontSize: 11, fill: '#475569' }}
+                                width={120}
+                              />
+                              <Tooltip
+                                formatter={(value, name, { dataKey }) => {
+                                  if (dataKey === 'propertyNetAfterTax') {
+                                    return [currency(value), name];
+                                  }
+                                  return [formatPercent(value), name];
+                                }}
+                                labelFormatter={(label) => `LTV ${formatPercent(label)}`}
+                              />
+                              <Legend
+                                content={(props) => (
+                                  <ChartLegend
+                                    {...props}
+                                    activeSeries={leverageSeriesActive}
+                                    onToggle={toggleLeverageSeries}
+                                  />
+                                )}
+                              />
+                              <RechartsLine
+                                type="monotone"
+                                dataKey="irr"
+                                name="IRR"
+                                yAxisId="left"
+                                stroke={SERIES_COLORS.irrSeries}
+                                strokeWidth={2}
+                                dot={{ r: 3 }}
+                                isAnimationActive={false}
+                                hide={!leverageSeriesActive.irr}
+                              />
+                              <RechartsLine
+                                type="monotone"
+                                dataKey="roi"
+                                name="Total ROI"
+                                yAxisId="left"
+                                stroke="#0ea5e9"
+                                strokeWidth={2}
+                                strokeDasharray="4 2"
+                                dot={{ r: 3 }}
+                                isAnimationActive={false}
+                                hide={!leverageSeriesActive.roi}
+                              />
+                              <RechartsLine
+                                type="monotone"
+                                dataKey="propertyNetAfterTax"
+                                name={propertyNetAfterTaxLabel}
+                                yAxisId="right"
+                                stroke={SERIES_COLORS.propertyNetAfterTax}
+                                strokeWidth={2}
+                                dot={{ r: 3 }}
+                                isAnimationActive={false}
+                                hide={!leverageSeriesActive.propertyNetAfterTax}
+                              />
+                            </LineChart>
+                          </ResponsiveContainer>
+                          {leverageEfficiencyData.length > 0 ? (
+                            <div className="mt-4 overflow-x-auto">
+                              <table className="min-w-full table-fixed border-separate border-spacing-1 text-[11px] text-slate-600">
+                                <thead>
+                                  <tr>
+                                    <th className="px-2 py-1 text-left font-semibold text-slate-500">LTV</th>
+                                    <th className="px-2 py-1 text-right font-semibold text-slate-500">IRR</th>
+                                    <th className="px-2 py-1 text-right font-semibold text-slate-500">Total ROI</th>
+                                    <th className="px-2 py-1 text-right font-semibold text-slate-500">{propertyNetAfterTaxLabel}</th>
+                                    <th className="px-2 py-1 text-right font-semibold text-slate-500">IRR × Profit</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {leverageEfficiencyData.map((row) => (
+                                    <tr key={row.ltv} className="odd:bg-slate-50">
+                                      <td className="px-2 py-1 text-left font-semibold text-slate-600">{formatPercent(row.ltv)}</td>
+                                      <td className="px-2 py-1 text-right text-slate-700">{formatPercent(row.irr)}</td>
+                                      <td className="px-2 py-1 text-right text-slate-700">{formatPercent(row.roi)}</td>
+                                      <td className="px-2 py-1 text-right text-slate-700">{currency(row.propertyNetAfterTax)}</td>
+                                      <td className="px-2 py-1 text-right text-slate-700">{currency(row.efficiency)}</td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          ) : null}
+                        </>
                       ) : (
                         <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 px-4 text-center text-[11px] text-slate-500">
                           Enter a purchase price and rent to explore leverage outcomes.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1238,6 +1238,7 @@ export default function App() {
     purchaseCosts: false,
     rentalCashflow: false,
     cashflowDetail: false,
+    wealthTrajectory: false,
   });
   const [cashflowColumnKeys, setCashflowColumnKeys] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -3313,114 +3314,132 @@ export default function App() {
 
             <div className="rounded-2xl bg-white p-3 shadow-sm">
               <div className="mb-2 flex items-center justify-between gap-3">
-                <SectionTitle
-                  label="Wealth trajectory vs Index Fund"
-                  tooltip={SECTION_DESCRIPTIONS.wealthTrajectory}
-                  className="text-sm font-semibold text-slate-700"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowChartModal(true)}
-                  className="no-print inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                >
-                  Expand chart
-                </button>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleSection('wealthTrajectory')}
+                    aria-expanded={!collapsedSections.wealthTrajectory}
+                    className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                  >
+                    {collapsedSections.wealthTrajectory ? 'Show chart' : 'Hide chart'}
+                  </button>
+                  <SectionTitle
+                    label="Wealth trajectory vs Index Fund"
+                    tooltip={SECTION_DESCRIPTIONS.wealthTrajectory}
+                    className="text-sm font-semibold text-slate-700"
+                  />
+                </div>
+                {!collapsedSections.wealthTrajectory ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowChartModal(true)}
+                    className="no-print inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                  >
+                    Expand chart
+                  </button>
+                ) : null}
               </div>
-              <div className="mb-2 flex items-center gap-2 text-[11px] text-slate-500">
-                <span>Showing years {chartRange.start} – {chartRange.end}</span>
-              </div>
-              <div className="h-72 w-full">
-                <ResponsiveContainer>
-                  <AreaChart data={filteredChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis
-                      dataKey="year"
-                      tickFormatter={(t) => `Y${t}`}
-                      tick={{ fontSize: 10, fill: '#475569' }}
-                    />
-                    <YAxis
-                      tickFormatter={(v) => currency(v)}
-                      tick={{ fontSize: 10, fill: '#475569' }}
-                      width={90}
-                    />
-                    <Tooltip formatter={(v) => currency(v)} labelFormatter={(l) => `Year ${l}`} />
-                    <Legend
-                      content={(props) => (
-                        <ChartLegend
-                          {...props}
-                          activeSeries={activeSeries}
-                          onToggle={toggleSeries}
-                          excludedKeys={reinvestActive ? [] : ['investedRent']}
+              {!collapsedSections.wealthTrajectory ? (
+                <>
+                  <div className="mb-2 flex items-center gap-2 text-[11px] text-slate-500">
+                    <span>Showing years {chartRange.start} – {chartRange.end}</span>
+                  </div>
+                  <div className="h-72 w-full">
+                    <ResponsiveContainer>
+                      <AreaChart data={filteredChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis
+                          dataKey="year"
+                          tickFormatter={(t) => `Y${t}`}
+                          tick={{ fontSize: 10, fill: '#475569' }}
                         />
-                      )}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="indexFund"
-                      name="Index fund"
-                      stroke="#f97316"
-                      fill="rgba(249,115,22,0.2)"
-                      strokeWidth={2}
-                      hide={!activeSeries.indexFund}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="cashflow"
-                      name="Cashflow"
-                      stroke="#facc15"
-                      fill="rgba(250,204,21,0.2)"
-                      strokeWidth={2}
-                      hide={!activeSeries.cashflow}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="propertyValue"
-                      name="Property value"
-                      stroke="#0ea5e9"
-                      fill="rgba(14,165,233,0.18)"
-                      strokeWidth={2}
-                      hide={!activeSeries.propertyValue}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="propertyGross"
-                      name="Property gross"
-                      stroke="#2563eb"
-                      fill="rgba(37,99,235,0.2)"
-                      strokeWidth={2}
-                      hide={!activeSeries.propertyGross}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="propertyNet"
-                      name="Property net"
-                      stroke="#16a34a"
-                      fill="rgba(22,163,74,0.25)"
-                      strokeWidth={2}
-                      hide={!activeSeries.propertyNet}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="propertyNetAfterTax"
-                      name={propertyNetAfterTaxLabel}
-                      stroke="#9333ea"
-                      fill="rgba(147,51,234,0.2)"
-                      strokeWidth={2}
-                      hide={!activeSeries.propertyNetAfterTax}
-                    />
-                    <Area
-                      type="monotone"
-                      dataKey="investedRent"
-                      name="Invested rent"
-                      stroke="#0d9488"
-                      fill="rgba(13,148,136,0.15)"
-                      strokeWidth={2}
-                      strokeDasharray="5 3"
-                      hide={!activeSeries.investedRent || !reinvestActive}
-                    />
-                  </AreaChart>
-                </ResponsiveContainer>
-              </div>
+                        <YAxis
+                          tickFormatter={(v) => currency(v)}
+                          tick={{ fontSize: 10, fill: '#475569' }}
+                          width={90}
+                        />
+                        <Tooltip formatter={(v) => currency(v)} labelFormatter={(l) => `Year ${l}`} />
+                        <Legend
+                          content={(props) => (
+                            <ChartLegend
+                              {...props}
+                              activeSeries={activeSeries}
+                              onToggle={toggleSeries}
+                              excludedKeys={reinvestActive ? [] : ['investedRent']}
+                            />
+                          )}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="indexFund"
+                          name="Index fund"
+                          stroke="#f97316"
+                          fill="rgba(249,115,22,0.2)"
+                          strokeWidth={2}
+                          hide={!activeSeries.indexFund}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="cashflow"
+                          name="Cashflow"
+                          stroke="#facc15"
+                          fill="rgba(250,204,21,0.2)"
+                          strokeWidth={2}
+                          hide={!activeSeries.cashflow}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="propertyValue"
+                          name="Property value"
+                          stroke="#0ea5e9"
+                          fill="rgba(14,165,233,0.18)"
+                          strokeWidth={2}
+                          hide={!activeSeries.propertyValue}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="propertyGross"
+                          name="Property gross"
+                          stroke="#2563eb"
+                          fill="rgba(37,99,235,0.2)"
+                          strokeWidth={2}
+                          hide={!activeSeries.propertyGross}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="propertyNet"
+                          name="Property net"
+                          stroke="#16a34a"
+                          fill="rgba(22,163,74,0.25)"
+                          strokeWidth={2}
+                          hide={!activeSeries.propertyNet}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="propertyNetAfterTax"
+                          name={propertyNetAfterTaxLabel}
+                          stroke="#9333ea"
+                          fill="rgba(147,51,234,0.2)"
+                          strokeWidth={2}
+                          hide={!activeSeries.propertyNetAfterTax}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="investedRent"
+                          name="Invested rent"
+                          stroke="#0d9488"
+                          fill="rgba(13,148,136,0.15)"
+                          strokeWidth={2}
+                          strokeDasharray="5 3"
+                          hide={!activeSeries.investedRent || !reinvestActive}
+                        />
+                      </AreaChart>
+                    </ResponsiveContainer>
+                  </div>
+                </>
+              ) : (
+                <div className="text-[11px] text-slate-500">Chart hidden. Select “Show chart” to display it.</div>
+              )}
             </div>
 
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1293,7 +1293,7 @@ export default function App() {
     householdIncome: false,
     purchaseCosts: false,
     rentalCashflow: false,
-    cashflowDetail: false,
+    cashflowDetail: true,
     wealthTrajectory: false,
     rateTrends: true,
     cashflowBars: true,
@@ -3598,22 +3598,7 @@ export default function App() {
             
 
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-              <div className="order-1 md:order-1">
-                <SummaryCard title={`At exit (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exit}>
-                  <Line label="Future value" value={currency(equity.futureValue)} tooltip={futureValueTooltip} />
-                  <Line label="Remaining loan" value={currency(equity.remaining)} tooltip={remainingLoanTooltip} />
-                  <Line label="Selling costs" value={currency(equity.sellingCosts)} tooltip={sellingCostsTooltip} />
-                  <hr className="my-2" />
-                  <Line
-                    label="Estimated equity then"
-                    value={currency(estimatedExitEquity)}
-                    bold
-                    tooltip={estimatedEquityTooltip}
-                  />
-                </SummaryCard>
-              </div>
-
-              <div className="order-2 md:order-2">
+              <div className="md:col-span-1">
                 <SummaryCard title={`Exit comparison (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exitComparison}>
                   <Line label="Index fund value" value={currency(equity.indexValEnd)} tooltip={indexFundTooltip} />
                   <Line
@@ -3639,6 +3624,21 @@ export default function App() {
                       ? `${afterTaxComparisonPrefix}, the index fund pulls ahead.`
                       : `${afterTaxComparisonPrefix}, both paths are broadly similar.`}
                   </div>
+                </SummaryCard>
+              </div>
+
+              <div className="md:col-span-1">
+                <SummaryCard title={`Equity at exit (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exit}>
+                  <Line label="Future value" value={currency(equity.futureValue)} tooltip={futureValueTooltip} />
+                  <Line label="Remaining loan" value={currency(equity.remaining)} tooltip={remainingLoanTooltip} />
+                  <Line label="Selling costs" value={currency(equity.sellingCosts)} tooltip={sellingCostsTooltip} />
+                  <hr className="my-2" />
+                  <Line
+                    label="Estimated equity then"
+                    value={currency(estimatedExitEquity)}
+                    bold
+                    tooltip={estimatedEquityTooltip}
+                  />
                 </SummaryCard>
               </div>
             </div>
@@ -3779,551 +3779,572 @@ export default function App() {
               ) : null}
             </div>
 
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('interestSplit')}
-                    aria-expanded={!collapsedSections.interestSplit}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.interestSplit ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.interestSplit ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Interest vs principal split"
-                    tooltip={SECTION_DESCRIPTIONS.interestSplit}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-              </div>
-              {!collapsedSections.interestSplit ? (
-                <div className="h-72 w-full">
-                  {hasInterestSplitData ? (
-                    <ResponsiveContainer>
-                      <AreaChart data={interestSplitChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 11, fill: '#475569' }} />
-                        <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 11, fill: '#475569' }} width={110} />
-                        <Tooltip formatter={(value) => currency(value)} labelFormatter={(label) => `Year ${label}`} />
-                        <Legend />
-                        <Area
-                          type="monotone"
-                          dataKey="interestPaid"
-                          name="Interest"
-                          stackId="payments"
-                          stroke="#f97316"
-                          fill="rgba(249,115,22,0.25)"
-                          strokeWidth={2}
-                          isAnimationActive={false}
-                        />
-                        <Area
-                          type="monotone"
-                          dataKey="principalPaid"
-                          name="Principal"
-                          stackId="payments"
-                          stroke="#22c55e"
-                          fill="rgba(34,197,94,0.3)"
-                          strokeWidth={2}
-                          isAnimationActive={false}
-                        />
-                      </AreaChart>
-                    </ResponsiveContainer>
-                  ) : (
-                    <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 px-4 text-center text-[11px] text-slate-500">
-                      Adjust the mortgage assumptions to model interest and principal payments.
-                    </div>
-                  )}
-                </div>
-              ) : null}
-            </div>
-
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('rateTrends')}
-                    aria-expanded={!collapsedSections.rateTrends}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.rateTrends ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.rateTrends ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Return ratios over time"
-                    tooltip={SECTION_DESCRIPTIONS.rateTrends}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-                {!collapsedSections.rateTrends ? (
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div
+                className={`rounded-2xl bg-white p-3 shadow-sm ${
+                  collapsedSections.rateTrends ? 'md:col-span-1' : 'md:col-span-2'
+                }`}
+              >
+                <div className="mb-2 flex items-center justify-between gap-3">
                   <div className="flex items-center gap-2">
                     <button
                       type="button"
-                      onClick={() => {
-                        setRateChartRange({ start: 0, end: maxChartYear });
-                        setRateRangeTouched(false);
-                      }}
-                      className="hidden items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100 sm:inline-flex"
+                      onClick={() => toggleSection('rateTrends')}
+                      aria-expanded={!collapsedSections.rateTrends}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      aria-label={collapsedSections.rateTrends ? 'Show chart' : 'Hide chart'}
                     >
-                      Reset range
+                      {collapsedSections.rateTrends ? '+' : '−'}
                     </button>
-                    <button
-                      type="button"
-                      onClick={() => setShowRatesModal(true)}
-                      className="no-print inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    >
-                      Expand chart
-                    </button>
+                    <SectionTitle
+                      label="Return ratios over time"
+                      tooltip={SECTION_DESCRIPTIONS.rateTrends}
+                      className="text-sm font-semibold text-slate-700"
+                    />
                   </div>
+                  {!collapsedSections.rateTrends ? (
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setRateChartRange({ start: 0, end: maxChartYear });
+                          setRateRangeTouched(false);
+                        }}
+                        className="hidden items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100 sm:inline-flex"
+                      >
+                        Reset range
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setShowRatesModal(true)}
+                        className="no-print inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      >
+                        Expand chart
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+                {!collapsedSections.rateTrends ? (
+                  <>
+                    <div className="mb-2 flex flex-wrap items-center justify-between gap-3 text-[11px] text-slate-500">
+                      <span>Years {rateChartRange.start} – {rateChartRange.end}</span>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setRateChartRange({ start: 0, end: maxChartYear });
+                          setRateRangeTouched(false);
+                        }}
+                        className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-100 sm:hidden"
+                      >
+                        Reset range
+                      </button>
+                    </div>
+                    <div className="h-72 w-full">
+                      {rateChartDataWithMovingAverage.length > 0 ? (
+                        <ResponsiveContainer>
+                          <LineChart data={rateChartDataWithMovingAverage} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis
+                              dataKey="year"
+                              tickFormatter={(t) => `Y${t}`}
+                              tick={{ fontSize: 10, fill: '#475569' }}
+                            />
+                            <YAxis
+                              yAxisId="percent"
+                              tickFormatter={(v) => formatPercent(v)}
+                              tick={{ fontSize: 10, fill: '#475569' }}
+                              width={70}
+                            />
+                            <Tooltip formatter={(value) => formatPercent(value)} labelFormatter={(label) => `Year ${label}`} />
+                            <Legend
+                              content={(props) => (
+                                <ChartLegend
+                                  {...props}
+                                  activeSeries={rateSeriesActive}
+                                  onToggle={toggleRateSeries}
+                                  excludedKeys={RATE_SERIES_KEYS.map((key) => `${key}MA`)}
+                                />
+                              )}
+                            />
+                            {rateChartSettings.showZeroBaseline ? (
+                              <ReferenceLine y={0} yAxisId="percent" stroke="#cbd5f5" strokeDasharray="4 4" />
+                            ) : null}
+                            {RATE_SERIES_KEYS.map((key) => (
+                              <RechartsLine
+                                key={key}
+                                type="monotone"
+                                dataKey={key}
+                                name={SERIES_LABELS[key] ?? key}
+                                stroke={SERIES_COLORS[key]}
+                                strokeWidth={2}
+                                dot={false}
+                                yAxisId="percent"
+                                hide={!rateSeriesActive[key]}
+                              />
+                            ))}
+                            {rateChartSettings.showMovingAverage
+                              ? RATE_SERIES_KEYS.map((key) => (
+                                  <RechartsLine
+                                    key={`${key}MA`}
+                                    type="monotone"
+                                    dataKey={`${key}MA`}
+                                    stroke={SERIES_COLORS[key]}
+                                    strokeWidth={1.5}
+                                    strokeDasharray="4 3"
+                                    dot={false}
+                                    yAxisId="percent"
+                                    hide={!rateSeriesActive[key]}
+                                    legendType="none"
+                                    isAnimationActive={false}
+                                    strokeOpacity={0.6}
+                                  />
+                                ))
+                              : null}
+                          </LineChart>
+                        </ResponsiveContainer>
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-center text-[11px] text-slate-500">
+                          Not enough data to plot return ratios yet.
+                        </div>
+                      )}
+                    </div>
+                  </>
                 ) : null}
               </div>
-              {!collapsedSections.rateTrends ? (
-                <>
-                  <div className="mb-2 flex flex-wrap items-center justify-between gap-3 text-[11px] text-slate-500">
-                    <span>
-                      Years {rateChartRange.start} – {rateChartRange.end}
-                    </span>
+              <div
+                className={`rounded-2xl bg-white p-3 shadow-sm ${
+                  collapsedSections.equityGrowth ? 'md:col-span-1' : 'md:col-span-2'
+                }`}
+              >
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
                     <button
                       type="button"
-                      onClick={() => {
-                        setRateChartRange({ start: 0, end: maxChartYear });
-                        setRateRangeTouched(false);
-                      }}
-                      className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-100 sm:hidden"
+                      onClick={() => toggleSection('equityGrowth')}
+                      aria-expanded={!collapsedSections.equityGrowth}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      aria-label={collapsedSections.equityGrowth ? 'Show chart' : 'Hide chart'}
                     >
-                      Reset range
+                      {collapsedSections.equityGrowth ? '+' : '−'}
                     </button>
+                    <SectionTitle
+                      label="Equity growth over time"
+                      tooltip={SECTION_DESCRIPTIONS.equityGrowth}
+                      className="text-sm font-semibold text-slate-700"
+                    />
                   </div>
-                  <div className="h-72 w-full">
-                    {rateChartDataWithMovingAverage.length > 0 ? (
-                      <ResponsiveContainer>
-                        <LineChart data={rateChartDataWithMovingAverage} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis
-                            dataKey="year"
-                            tickFormatter={(t) => `Y${t}`}
-                            tick={{ fontSize: 10, fill: '#475569' }}
-                          />
-                          <YAxis
-                            yAxisId="percent"
-                            tickFormatter={(v) => formatPercent(v)}
-                            tick={{ fontSize: 10, fill: '#475569' }}
-                            width={70}
-                          />
-                          <Tooltip formatter={(value) => formatPercent(value)} labelFormatter={(label) => `Year ${label}`} />
-                          <Legend
-                            content={(props) => (
-                              <ChartLegend
-                                {...props}
-                                activeSeries={rateSeriesActive}
-                                onToggle={toggleRateSeries}
-                                excludedKeys={RATE_SERIES_KEYS.map((key) => `${key}MA`)}
-                              />
-                            )}
-                          />
-                          {rateChartSettings.showZeroBaseline ? (
-                            <ReferenceLine y={0} yAxisId="percent" stroke="#cbd5f5" strokeDasharray="4 4" />
-                          ) : null}
-                          {RATE_SERIES_KEYS.map((key) => (
-                            <RechartsLine
-                              key={key}
-                              type="monotone"
-                              dataKey={key}
-                              name={SERIES_LABELS[key] ?? key}
-                              stroke={SERIES_COLORS[key]}
-                              strokeWidth={2}
-                              dot={false}
-                              yAxisId="percent"
-                              hide={!rateSeriesActive[key]}
-                            />
-                          ))}
-                          {rateChartSettings.showMovingAverage
-                            ? RATE_SERIES_KEYS.map((key) => (
-                                <RechartsLine
-                                  key={`${key}MA`}
-                                  type="monotone"
-                                  dataKey={`${key}MA`}
-                                  stroke={SERIES_COLORS[key]}
-                                  strokeWidth={1.5}
-                                  strokeDasharray="4 3"
-                                  dot={false}
-                                  yAxisId="percent"
-                                  hide={!rateSeriesActive[key]}
-                                  legendType="none"
-                                  isAnimationActive={false}
-                                  strokeOpacity={0.6}
-                                />
-                              ))
-                            : null}
-                        </LineChart>
-                      </ResponsiveContainer>
-                    ) : (
-                      <div className="flex h-full items-center justify-center text-center text-[11px] text-slate-500">
-                        Not enough data to plot return ratios yet.
-                      </div>
-                    )}
-                  </div>
-                </>
-              ) : null}
-            </div>
-
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('equityGrowth')}
-                    aria-expanded={!collapsedSections.equityGrowth}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.equityGrowth ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.equityGrowth ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Equity growth over time"
-                    tooltip={SECTION_DESCRIPTIONS.equityGrowth}
-                    className="text-sm font-semibold text-slate-700"
-                  />
                 </div>
+                {!collapsedSections.equityGrowth ? (
+                  <>
+                    <p className="mb-2 text-[11px] text-slate-500">
+                      See how outstanding debt compares with the portion you own as the property appreciates and the mortgage is repaid.
+                    </p>
+                    <div className="h-72 w-full">
+                      {equityGrowthChartData.length > 0 ? (
+                        <ResponsiveContainer>
+                          <AreaChart data={equityGrowthChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 10, fill: '#475569' }} />
+                            <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 10, fill: '#475569' }} width={100} />
+                            <Tooltip
+                              formatter={(value, name) => currency(value)}
+                              labelFormatter={(label) => `Year ${label}`}
+                            />
+                            <Legend />
+                            <Area
+                              type="monotone"
+                              dataKey="loanBalance"
+                              name="Lender share"
+                              stackId="equity"
+                              stroke="#94a3b8"
+                              fill="rgba(148,163,184,0.4)"
+                              isAnimationActive={false}
+                            />
+                            <Area
+                              type="monotone"
+                              dataKey="ownerEquity"
+                              name="Your equity"
+                              stackId="equity"
+                              stroke="#10b981"
+                              fill="rgba(16,185,129,0.35)"
+                              isAnimationActive={false}
+                            />
+                          </AreaChart>
+                        </ResponsiveContainer>
+                      ) : (
+                        <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 text-center text-[11px] text-slate-500">
+                          Equity projections will appear once an exit year and loan details are provided.
+                        </div>
+                      )}
+                    </div>
+                  </>
+                ) : null}
               </div>
-              {!collapsedSections.equityGrowth ? (
-                <>
-                  <p className="mb-2 text-[11px] text-slate-500">
-                    See how outstanding debt compares with the portion you own as the property appreciates and the mortgage is repaid.
-                  </p>
+              <div
+                className={`rounded-2xl bg-white p-3 shadow-sm ${
+                  collapsedSections.cashflowBars ? 'md:col-span-1' : 'md:col-span-2'
+                }`}
+              >
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleSection('cashflowBars')}
+                      aria-expanded={!collapsedSections.cashflowBars}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      aria-label={collapsedSections.cashflowBars ? 'Show chart' : 'Hide chart'}
+                    >
+                      {collapsedSections.cashflowBars ? '+' : '−'}
+                    </button>
+                    <SectionTitle
+                      label="Annual cash flow"
+                      tooltip={SECTION_DESCRIPTIONS.cashflowBars}
+                      className="text-sm font-semibold text-slate-700"
+                    />
+                  </div>
+                </div>
+                {!collapsedSections.cashflowBars ? (
+                  <>
+                    <p className="mb-2 text-[11px] text-slate-500">
+                      Track rent coming in against expenses, debt service, and after-tax cash flow each year.
+                    </p>
+                    <div className="h-72 w-full">
+                      {annualCashflowChartData.length > 0 ? (
+                        <ResponsiveContainer>
+                          <BarChart data={annualCashflowChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 10, fill: '#475569' }} />
+                            <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 10, fill: '#475569' }} width={90} />
+                            <Tooltip formatter={(value) => currency(value)} labelFormatter={(label) => `Year ${label}`} />
+                            <Legend
+                              content={(props) => (
+                                <ChartLegend
+                                  {...props}
+                                  activeSeries={cashflowSeriesActive}
+                                  onToggle={toggleCashflowSeries}
+                                />
+                              )}
+                            />
+                            <ReferenceLine y={0} stroke="#cbd5f5" strokeDasharray="4 4" />
+                            <Bar
+                              dataKey="rentIncome"
+                              name="Rent income"
+                              fill={CASHFLOW_BAR_COLORS.rentIncome}
+                              isAnimationActive={false}
+                              hide={!cashflowSeriesActive.rentIncome}
+                            />
+                            <Bar
+                              dataKey="operatingExpenses"
+                              name="Operating expenses"
+                              fill={CASHFLOW_BAR_COLORS.operatingExpenses}
+                              isAnimationActive={false}
+                              hide={!cashflowSeriesActive.operatingExpenses}
+                            />
+                            <Bar
+                              dataKey="mortgagePayments"
+                              name="Mortgage payments"
+                              fill={CASHFLOW_BAR_COLORS.mortgagePayments}
+                              isAnimationActive={false}
+                              hide={!cashflowSeriesActive.mortgagePayments}
+                            />
+                            <Bar
+                              dataKey="netCashflow"
+                              name="After-tax cash flow"
+                              fill={CASHFLOW_BAR_COLORS.netCashflow}
+                              isAnimationActive={false}
+                              hide={!cashflowSeriesActive.netCashflow}
+                            />
+                          </BarChart>
+                        </ResponsiveContainer>
+                      ) : (
+                        <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 text-center text-[11px] text-slate-500">
+                          Not enough annual cash flow data to display.
+                        </div>
+                      )}
+                    </div>
+                  </>
+                ) : null}
+              </div>
+              <div
+                className={`rounded-2xl bg-white p-3 shadow-sm ${
+                  collapsedSections.interestSplit ? 'md:col-span-1' : 'md:col-span-2'
+                }`}
+              >
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleSection('interestSplit')}
+                      aria-expanded={!collapsedSections.interestSplit}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      aria-label={collapsedSections.interestSplit ? 'Show chart' : 'Hide chart'}
+                    >
+                      {collapsedSections.interestSplit ? '+' : '−'}
+                    </button>
+                    <SectionTitle
+                      label="Interest vs principal split"
+                      tooltip={SECTION_DESCRIPTIONS.interestSplit}
+                      className="text-sm font-semibold text-slate-700"
+                    />
+                  </div>
+                </div>
+                {!collapsedSections.interestSplit ? (
                   <div className="h-72 w-full">
-                    {equityGrowthChartData.length > 0 ? (
+                    {hasInterestSplitData ? (
                       <ResponsiveContainer>
-                        <AreaChart data={equityGrowthChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                        <AreaChart data={interestSplitChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
                           <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 10, fill: '#475569' }} />
-                          <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 10, fill: '#475569' }} width={100} />
-                          <Tooltip
-                            formatter={(value, name) => currency(value)}
-                            labelFormatter={(label) => `Year ${label}`}
-                          />
+                          <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 11, fill: '#475569' }} />
+                          <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 11, fill: '#475569' }} width={110} />
+                          <Tooltip formatter={(value) => currency(value)} labelFormatter={(label) => `Year ${label}`} />
                           <Legend />
                           <Area
                             type="monotone"
-                            dataKey="loanBalance"
-                            name="Lender share"
-                            stackId="equity"
-                            stroke="#94a3b8"
-                            fill="rgba(148,163,184,0.4)"
+                            dataKey="interestPaid"
+                            name="Interest"
+                            stackId="payments"
+                            stroke="#f97316"
+                            fill="rgba(249,115,22,0.25)"
+                            strokeWidth={2}
                             isAnimationActive={false}
                           />
                           <Area
                             type="monotone"
-                            dataKey="ownerEquity"
-                            name="Your equity"
-                            stackId="equity"
-                            stroke="#10b981"
-                            fill="rgba(16,185,129,0.35)"
+                            dataKey="principalPaid"
+                            name="Principal"
+                            stackId="payments"
+                            stroke="#22c55e"
+                            fill="rgba(34,197,94,0.3)"
+                            strokeWidth={2}
                             isAnimationActive={false}
                           />
                         </AreaChart>
                       </ResponsiveContainer>
                     ) : (
-                      <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 text-center text-[11px] text-slate-500">
-                        Equity projections will appear once an exit year and loan details are provided.
-                      </div>
-                    )}
-                  </div>
-                </>
-              ) : null}
-            </div>
-
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('cashflowBars')}
-                    aria-expanded={!collapsedSections.cashflowBars}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.cashflowBars ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.cashflowBars ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Annual cash flow"
-                    tooltip={SECTION_DESCRIPTIONS.cashflowBars}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-              </div>
-              {!collapsedSections.cashflowBars ? (
-                <>
-                  <p className="mb-2 text-[11px] text-slate-500">
-                    Track rent coming in against expenses, debt service, and after-tax cash flow each year.
-                  </p>
-                  <div className="h-72 w-full">
-                    {annualCashflowChartData.length > 0 ? (
-                      <ResponsiveContainer>
-                        <BarChart data={annualCashflowChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 10, fill: '#475569' }} />
-                          <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 10, fill: '#475569' }} width={90} />
-                          <Tooltip formatter={(value) => currency(value)} labelFormatter={(label) => `Year ${label}`} />
-                          <Legend
-                            content={(props) => (
-                              <ChartLegend
-                                {...props}
-                                activeSeries={cashflowSeriesActive}
-                                onToggle={toggleCashflowSeries}
-                              />
-                            )}
-                          />
-                          <ReferenceLine y={0} stroke="#cbd5f5" strokeDasharray="4 4" />
-                          <Bar
-                            dataKey="rentIncome"
-                            name="Rent income"
-                            fill={CASHFLOW_BAR_COLORS.rentIncome}
-                            isAnimationActive={false}
-                            hide={!cashflowSeriesActive.rentIncome}
-                          />
-                          <Bar
-                            dataKey="operatingExpenses"
-                            name="Operating expenses"
-                            fill={CASHFLOW_BAR_COLORS.operatingExpenses}
-                            isAnimationActive={false}
-                            hide={!cashflowSeriesActive.operatingExpenses}
-                          />
-                          <Bar
-                            dataKey="mortgagePayments"
-                            name="Mortgage payments"
-                            fill={CASHFLOW_BAR_COLORS.mortgagePayments}
-                            isAnimationActive={false}
-                            hide={!cashflowSeriesActive.mortgagePayments}
-                          />
-                          <Bar
-                            dataKey="netCashflow"
-                            name="After-tax cash flow"
-                            fill={CASHFLOW_BAR_COLORS.netCashflow}
-                            isAnimationActive={false}
-                            hide={!cashflowSeriesActive.netCashflow}
-                          />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    ) : (
-                      <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 text-center text-[11px] text-slate-500">
-                        Not enough annual cash flow data to display.
-                      </div>
-                    )}
-                  </div>
-                </>
-              ) : null}
-            </div>
-
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('leverage')}
-                    aria-expanded={!collapsedSections.leverage}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.leverage ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.leverage ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Leverage multiplier"
-                    tooltip={SECTION_DESCRIPTIONS.leverage}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-              </div>
-              {!collapsedSections.leverage ? (
-                <>
-                  <p className="mb-2 text-[11px] text-slate-500">
-                    Each point recalculates the deal using the same assumptions but with a different LTV. ROI reflects net wealth at exit versus cash invested.
-                  </p>
-                  <div className="h-72 w-full">
-                    {hasLeverageData ? (
-                      <ResponsiveContainer>
-                        <LineChart data={leverageChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis
-                            dataKey="ltv"
-                            tickFormatter={(value) => formatPercent(value)}
-                            tick={{ fontSize: 11, fill: '#475569' }}
-                            domain={[0.1, 0.75]}
-                            type="number"
-                          />
-                          <YAxis
-                            tickFormatter={(value) => formatPercent(value)}
-                            tick={{ fontSize: 11, fill: '#475569' }}
-                            width={90}
-                          />
-                          <Tooltip
-                            formatter={(value, key) => [formatPercent(value), key === 'irr' ? 'IRR' : 'Total ROI']}
-                            labelFormatter={(label) => `LTV ${formatPercent(label)}`}
-                          />
-                          <Legend />
-                          <RechartsLine
-                            type="monotone"
-                            dataKey="irr"
-                            name="IRR"
-                            stroke={SERIES_COLORS.irrSeries}
-                            strokeWidth={2}
-                            dot={{ r: 3 }}
-                            isAnimationActive={false}
-                          />
-                          <RechartsLine
-                            type="monotone"
-                            dataKey="roi"
-                            name="Total ROI"
-                            stroke="#0ea5e9"
-                            strokeWidth={2}
-                            strokeDasharray="4 2"
-                            dot={{ r: 3 }}
-                            isAnimationActive={false}
-                          />
-                        </LineChart>
-                      </ResponsiveContainer>
-                    ) : (
                       <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 px-4 text-center text-[11px] text-slate-500">
-                        Enter a purchase price and rent to explore leverage outcomes.
+                        Adjust the mortgage assumptions to model interest and principal payments.
                       </div>
                     )}
-                  </div>
-                </>
-              ) : null}
-            </div>
-
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('roiHeatmap')}
-                    aria-expanded={!collapsedSections.roiHeatmap}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.roiHeatmap ? 'Show heatmap' : 'Hide heatmap'}
-                  >
-                    {collapsedSections.roiHeatmap ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="ROI vs rental yield heatmap"
-                    tooltip={SECTION_DESCRIPTIONS.roiHeatmap}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-                {!collapsedSections.roiHeatmap ? (
-                  <div className="flex items-center gap-2 text-[11px] text-slate-600">
-                    <span className="font-semibold text-slate-500">Metric</span>
-                    {[{ key: 'irr', label: 'IRR' }, { key: 'roi', label: 'Total ROI' }].map((option) => (
-                      <button
-                        key={option.key}
-                        type="button"
-                        onClick={() => setRoiHeatmapMetric(option.key)}
-                        className={`rounded-full px-3 py-1 font-semibold transition ${
-                          roiHeatmapMetric === option.key
-                            ? 'bg-slate-900 text-white'
-                            : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
-                        }`}
-                        aria-pressed={roiHeatmapMetric === option.key}
-                      >
-                        {option.label}
-                      </button>
-                    ))}
                   </div>
                 ) : null}
               </div>
-              {!collapsedSections.roiHeatmap ? (
-                <>
-                  <p className="mb-2 text-[11px] text-slate-500">
-                    Each cell models the scenario with the specified rental yield and annual capital growth using today’s inputs.
-                  </p>
-                  <div className="overflow-x-auto">
-                    {roiHeatmapData.rows.length > 0 ? (
-                      <table className="min-w-full table-fixed border-separate border-spacing-1 text-[11px] text-slate-600">
-                        <thead>
-                          <tr>
-                            <th className="w-32 px-2 py-1 text-left font-semibold text-slate-500">Capital growth</th>
-                            {ROI_HEATMAP_YIELD_OPTIONS.map((yieldRate) => (
-                              <th key={yieldRate} className="px-2 py-1 text-center font-semibold text-slate-500">
-                                {formatPercent(yieldRate)} rent yield
-                              </th>
-                            ))}
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {roiHeatmapData.rows.map((row) => {
-                            const range = roiHeatmapMetric === 'irr' ? roiHeatmapData.irrRange : roiHeatmapData.roiRange;
-                            const [minValue, maxValue] = range;
-                            return (
-                              <tr key={row.growthRate}>
-                                <th className="px-2 py-1 text-left font-semibold text-slate-500">
-                                  {formatPercent(row.growthRate)} capital growth
-                                </th>
-                                {row.cells.map((cell) => {
-                                  const value = roiHeatmapMetric === 'irr' ? cell.irr : cell.roi;
-                                  const background = getHeatmapColor(value, minValue, maxValue);
-                                  return (
-                                    <td key={cell.yieldRate} className="px-2 py-1">
-                                      <div
-                                        className="rounded-lg px-2 py-3 text-center text-xs font-semibold text-slate-800"
-                                        style={{ backgroundColor: background }}
-                                        title={`If rent yield is ${formatPercent(cell.yieldRate)} and capital growth is ${formatPercent(row.growthRate)}, expect ${formatPercent(value)} ${roiHeatmapMetric === 'irr' ? 'IRR' : 'total ROI'} (IRR ${formatPercent(cell.irr)}, total ROI ${formatPercent(cell.roi)}).`}
-                                      >
-                                        {formatPercent(value)}
-                                      </div>
-                                    </td>
-                                  );
-                                })}
-                              </tr>
-                            );
-                          })}
-                        </tbody>
-                      </table>
-                    ) : (
-                      <div className="rounded-xl border border-dashed border-slate-200 p-4 text-center text-[11px] text-slate-500">
-                        Adjust the purchase price and rent assumptions to generate heatmap results.
-                      </div>
-                    )}
-                  </div>
-                </>
-              ) : null}
-            </div>
-
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
               <div
-                className={`flex items-center justify-between gap-3 ${
-                  collapsedSections.cashflowDetail ? '' : 'mb-2'
+                className={`rounded-2xl bg-white p-3 shadow-sm ${
+                  collapsedSections.leverage ? 'md:col-span-1' : 'md:col-span-2'
                 }`}
               >
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('cashflowDetail')}
-                    aria-expanded={!collapsedSections.cashflowDetail}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.cashflowDetail ? 'Show cash flow table' : 'Hide cash flow table'}
-                  >
-                    {collapsedSections.cashflowDetail ? '+' : '−'}
-                  </button>
-                  <SectionTitle label="Annual cash flow detail" className="text-sm font-semibold text-slate-700" />
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleSection('leverage')}
+                      aria-expanded={!collapsedSections.leverage}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      aria-label={collapsedSections.leverage ? 'Show chart' : 'Hide chart'}
+                    >
+                      {collapsedSections.leverage ? '+' : '−'}
+                    </button>
+                    <SectionTitle
+                      label="Leverage multiplier"
+                      tooltip={SECTION_DESCRIPTIONS.leverage}
+                      className="text-sm font-semibold text-slate-700"
+                    />
+                  </div>
                 </div>
+                {!collapsedSections.leverage ? (
+                  <>
+                    <p className="mb-2 text-[11px] text-slate-500">
+                      Each point recalculates the deal using the same assumptions but with a different LTV. ROI reflects net wealth at exit versus cash invested.
+                    </p>
+                    <div className="h-72 w-full">
+                      {hasLeverageData ? (
+                        <ResponsiveContainer>
+                          <LineChart data={leverageChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis
+                              dataKey="ltv"
+                              tickFormatter={(value) => formatPercent(value)}
+                              tick={{ fontSize: 11, fill: '#475569' }}
+                              domain={[0.1, 0.75]}
+                              type="number"
+                            />
+                            <YAxis
+                              tickFormatter={(value) => formatPercent(value)}
+                              tick={{ fontSize: 11, fill: '#475569' }}
+                              width={90}
+                            />
+                            <Tooltip
+                              formatter={(value, key) => [formatPercent(value), key === 'irr' ? 'IRR' : 'Total ROI']}
+                              labelFormatter={(label) => `LTV ${formatPercent(label)}`}
+                            />
+                            <Legend />
+                            <RechartsLine
+                              type="monotone"
+                              dataKey="irr"
+                              name="IRR"
+                              stroke={SERIES_COLORS.irrSeries}
+                              strokeWidth={2}
+                              dot={{ r: 3 }}
+                              isAnimationActive={false}
+                            />
+                            <RechartsLine
+                              type="monotone"
+                              dataKey="roi"
+                              name="Total ROI"
+                              stroke="#0ea5e9"
+                              strokeWidth={2}
+                              strokeDasharray="4 2"
+                              dot={{ r: 3 }}
+                              isAnimationActive={false}
+                            />
+                          </LineChart>
+                        </ResponsiveContainer>
+                      ) : (
+                        <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 px-4 text-center text-[11px] text-slate-500">
+                          Enter a purchase price and rent to explore leverage outcomes.
+                        </div>
+                      )}
+                    </div>
+                  </>
+                ) : null}
               </div>
-              {!collapsedSections.cashflowDetail ? (
-                <>
-                  <p className="mb-2 text-[11px] text-slate-500">Per-year performance through exit.</p>
-                  <CashflowTable
-                    rows={cashflowTableRows}
-                    columns={selectedCashflowColumns}
-                    hiddenColumns={hiddenCashflowColumns}
-                    onRemoveColumn={handleRemoveCashflowColumn}
-                    onAddColumn={handleAddCashflowColumn}
-                    onExport={handleExportCashflowCsv}
-                  />
-                </>
-              ) : null}
+              <div
+                className={`rounded-2xl bg-white p-3 shadow-sm ${
+                  collapsedSections.roiHeatmap ? 'md:col-span-1' : 'md:col-span-2'
+                }`}
+              >
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleSection('roiHeatmap')}
+                      aria-expanded={!collapsedSections.roiHeatmap}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      aria-label={collapsedSections.roiHeatmap ? 'Show heatmap' : 'Hide heatmap'}
+                    >
+                      {collapsedSections.roiHeatmap ? '+' : '−'}
+                    </button>
+                    <SectionTitle
+                      label="ROI vs rental yield heatmap"
+                      tooltip={SECTION_DESCRIPTIONS.roiHeatmap}
+                      className="text-sm font-semibold text-slate-700"
+                    />
+                  </div>
+                  {!collapsedSections.roiHeatmap ? (
+                    <div className="flex items-center gap-2 text-[11px] text-slate-600">
+                      <span className="font-semibold text-slate-500">Metric</span>
+                      {[{ key: 'irr', label: 'IRR' }, { key: 'roi', label: 'Total ROI' }].map((option) => (
+                        <button
+                          key={option.key}
+                          type="button"
+                          onClick={() => setRoiHeatmapMetric(option.key)}
+                          className={`rounded-full px-3 py-1 font-semibold transition ${
+                            roiHeatmapMetric === option.key
+                              ? 'bg-slate-900 text-white'
+                              : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                          }`}
+                          aria-pressed={roiHeatmapMetric === option.key}
+                        >
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+                {!collapsedSections.roiHeatmap ? (
+                  <>
+                    <p className="mb-2 text-[11px] text-slate-500">
+                      Each cell models the scenario with the specified rental yield and annual capital growth using today’s inputs.
+                    </p>
+                    <div className="overflow-x-auto">
+                      {roiHeatmapData.rows.length > 0 ? (
+                        <table className="min-w-full table-fixed border-separate border-spacing-1 text-[11px] text-slate-600">
+                          <thead>
+                            <tr>
+                              <th className="w-32 px-2 py-1 text-left font-semibold text-slate-500">Capital growth</th>
+                              {ROI_HEATMAP_YIELD_OPTIONS.map((yieldRate) => (
+                                <th key={yieldRate} className="px-2 py-1 text-center font-semibold text-slate-500">
+                                  {formatPercent(yieldRate)} rent yield
+                                </th>
+                              ))}
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {roiHeatmapData.rows.map((row) => {
+                              const range = roiHeatmapMetric === 'irr' ? roiHeatmapData.irrRange : roiHeatmapData.roiRange;
+                              const [minValue, maxValue] = range;
+                              return (
+                                <tr key={row.growthRate}>
+                                  <th className="px-2 py-1 text-left font-semibold text-slate-500">
+                                    {formatPercent(row.growthRate)} capital growth
+                                  </th>
+                                  {row.cells.map((cell) => {
+                                    const value = roiHeatmapMetric === 'irr' ? cell.irr : cell.roi;
+                                    const background = getHeatmapColor(value, minValue, maxValue);
+                                    return (
+                                      <td key={cell.yieldRate} className="px-2 py-1">
+                                        <div
+                                          className="rounded-lg px-2 py-3 text-center text-xs font-semibold text-slate-800"
+                                          style={{ backgroundColor: background }}
+                                          title={`If rent yield is ${formatPercent(cell.yieldRate)} and capital growth is ${formatPercent(row.growthRate)}, expect ${formatPercent(value)} ${roiHeatmapMetric === 'irr' ? 'IRR' : 'total ROI'} (IRR ${formatPercent(cell.irr)}, total ROI ${formatPercent(cell.roi)}).`}
+                                        >
+                                          {formatPercent(value)}
+                                        </div>
+                                      </td>
+                                    );
+                                  })}
+                                </tr>
+                              );
+                            })}
+                          </tbody>
+                        </table>
+                      ) : (
+                        <div className="rounded-xl border border-dashed border-slate-200 p-4 text-center text-[11px] text-slate-500">
+                          Adjust the purchase price and rent assumptions to generate heatmap results.
+                        </div>
+                      )}
+                    </div>
+                  </>
+                ) : null}
+              </div>
+              <div
+                className={`rounded-2xl bg-white p-3 shadow-sm ${
+                  collapsedSections.cashflowDetail ? 'md:col-span-1' : 'md:col-span-2'
+                }`}
+              >
+                <div
+                  className={`flex items-center justify-between gap-3 ${
+                    collapsedSections.cashflowDetail ? '' : 'mb-2'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleSection('cashflowDetail')}
+                      aria-expanded={!collapsedSections.cashflowDetail}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      aria-label={collapsedSections.cashflowDetail ? 'Show cash flow table' : 'Hide cash flow table'}
+                    >
+                      {collapsedSections.cashflowDetail ? '+' : '−'}
+                    </button>
+                    <SectionTitle label="Annual cash flow detail" className="text-sm font-semibold text-slate-700" />
+                  </div>
+                </div>
+                {!collapsedSections.cashflowDetail ? (
+                  <>
+                    <p className="mb-2 text-[11px] text-slate-500">Per-year performance through exit.</p>
+                    <CashflowTable
+                      rows={cashflowTableRows}
+                      columns={selectedCashflowColumns}
+                      hiddenColumns={hiddenCashflowColumns}
+                      onRemoveColumn={handleRemoveCashflowColumn}
+                      onAddColumn={handleAddCashflowColumn}
+                      onExport={handleExportCashflowCsv}
+                    />
+                  </>
+                ) : null}
+              </div>
             </div>
-
 
 
 
@@ -4967,56 +4988,66 @@ export default function App() {
             <aside className="w-full border-t border-slate-200 bg-slate-50 text-xs text-slate-600 md:w-80 md:border-l md:border-t-0">
               <div className="h-full overflow-y-auto p-5 space-y-6">
                 <div>
+                  <h3 className="text-sm font-semibold text-slate-700">Exit & growth assumptions</h3>
+                  <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {smallInput('exitYear', 'Exit year', 1)}
+                    {pctInput('annualAppreciation', 'Capital growth %')}
+                    {pctInput('rentGrowth', 'Rent growth %')}
+                    {pctInput('indexFundGrowth', 'Index fund growth %')}
+                    {pctInput('sellingCostsPct', 'Selling costs %')}
+                    {pctInput('discountRate', 'Discount rate %', 0.001)}
+                  </div>
+                </div>
+                <div>
                   <h3 className="text-sm font-semibold text-slate-700">Deal levers</h3>
-                  <div className="mt-3 space-y-3">
+                  <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
                     {moneyInput('purchasePrice', 'Purchase price (£)', 1000)}
                     {pctInput('depositPct', 'Deposit %')}
-                    {smallInput('exitYear', 'Exit year', 1)}
                   </div>
                 </div>
                 <div>
                   <h3 className="text-sm font-semibold text-slate-700">Loan profile</h3>
-                  <div className="mt-3 space-y-3">
+                  <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
                     {pctInput('interestRate', 'Interest rate (APR) %', 0.001)}
                     {smallInput('mortgageYears', 'Mortgage term (years)')}
-                    <div className="rounded-xl border border-slate-200 bg-white p-3">
-                      <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Loan type</div>
-                      <div className="mt-3 space-y-2 text-[11px] text-slate-600">
-                        <label className="flex items-center justify-between gap-3">
-                          <span className="text-slate-700">Capital repayment</span>
-                          <input
-                            type="radio"
-                            name="modal-loan-type"
-                            checked={inputs.loanType === 'repayment'}
-                            onChange={() => setInputs((s) => ({ ...s, loanType: 'repayment' }))}
-                          />
-                        </label>
-                        <label className="flex items-center justify-between gap-3">
-                          <span className="text-slate-700">Interest-only</span>
-                          <input
-                            type="radio"
-                            name="modal-loan-type"
-                            checked={inputs.loanType === 'interest_only'}
-                            onChange={() => setInputs((s) => ({ ...s, loanType: 'interest_only' }))}
-                          />
-                        </label>
-                        <p className="text-[10px] text-slate-500">
-                          Interest-only keeps the balance level; repayment shifts cash flow toward principal over time.
-                        </p>
-                      </div>
+                  </div>
+                  <div className="mt-3 rounded-xl border border-slate-200 bg-white p-3">
+                    <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Loan type</div>
+                    <div className="mt-3 space-y-2 text-[11px] text-slate-600">
+                      <label className="flex items-center justify-between gap-3">
+                        <span className="text-slate-700">Capital repayment</span>
+                        <input
+                          type="radio"
+                          name="modal-loan-type"
+                          checked={inputs.loanType === 'repayment'}
+                          onChange={() => setInputs((s) => ({ ...s, loanType: 'repayment' }))}
+                        />
+                      </label>
+                      <label className="flex items-center justify-between gap-3">
+                        <span className="text-slate-700">Interest-only</span>
+                        <input
+                          type="radio"
+                          name="modal-loan-type"
+                          checked={inputs.loanType === 'interest_only'}
+                          onChange={() => setInputs((s) => ({ ...s, loanType: 'interest_only' }))}
+                        />
+                      </label>
+                      <p className="text-[10px] text-slate-500">
+                        Interest-only keeps the balance level; repayment shifts cash flow toward principal over time.
+                      </p>
                     </div>
                   </div>
                 </div>
                 <div>
-                  <h3 className="text-sm font-semibold text-slate-700">Rent & growth</h3>
-                  <div className="mt-3 space-y-3">
+                  <h3 className="text-sm font-semibold text-slate-700">Rent & cash flow</h3>
+                  <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
                     {moneyInput('monthlyRent', 'Monthly rent (£)', 50)}
-                    {pctInput('rentGrowth', 'Rent growth %')}
-                    {pctInput('annualAppreciation', 'Capital growth %')}
+                    {pctInput('vacancyPct', 'Vacancy %')}
+                    {pctInput('mgmtPct', 'Management %')}
+                    {pctInput('repairsPct', 'Repairs/CapEx %')}
+                    {moneyInput('insurancePerYear', 'Insurance (£/yr)', 50)}
+                    {moneyInput('otherOpexPerYear', 'Other OpEx (£/yr)', 50)}
                   </div>
-                </div>
-                <div>
-                  <h3 className="text-sm font-semibold text-slate-700">Cash flow options</h3>
                   <div className="mt-3 space-y-3">
                     <label className="flex items-start gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-[11px] text-slate-600">
                       <input
@@ -5036,7 +5067,11 @@ export default function App() {
                         </span>
                       </span>
                     </label>
-                    {inputs.reinvestIncome ? pctInput('reinvestPct', 'Reinvest % of after-tax cash flow') : null}
+                    {inputs.reinvestIncome ? (
+                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                        {pctInput('reinvestPct', 'Reinvest % of after-tax cash flow')}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -937,8 +937,10 @@ function calculateEquity(rawInputs) {
         annualInterest[yearIndex] += monthlyInterest;
       }
       if (month === monthsToModel) {
-        annualDebtService[yearIndex] += bridgingAmount;
-        annualPrincipal[yearIndex] += bridgingAmount;
+        // The bridging principal is refinanced into the long-term mortgage at the
+        // end of the term, so it should not be treated as an investor cash
+        // outflow in the annual debt service totals. We still keep the
+        // interest for the term above but skip adding the principal here.
       }
     }
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1909,7 +1909,7 @@ export default function App() {
       lat,
       lon,
       displayName: geocodeState.data.displayName,
-      imageUrl: `https://staticmap.openstreetmap.de/staticmap.php?center=${latFixed},${lonFixed}&zoom=15&size=400x220&markers=${latFixed},${lonFixed},red-pushpin`,
+      imageUrl: `https://staticmap.openstreetmap.org/staticmap.php?center=${latFixed},${lonFixed}&zoom=15&size=400x220&markers=${latFixed},${lonFixed},red-pushpin`,
     };
   }, [geocodeState.data]);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3537,7 +3537,7 @@ export default function App() {
             </section>
 
       <section className="md:col-span-2 md:self-stretch">
-        <div className="flex flex-col space-y-3 md:h-[calc(100vh-8rem)] md:min-h-[calc(100vh-8rem)] md:overflow-y-auto md:pr-2 md:pb-6">
+        <div className="flex flex-col space-y-3 md:pr-2 md:pb-6">
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <SummaryCard title="Cash needed" tooltip={SECTION_DESCRIPTIONS.cashNeeded}>
                 <Line label="Deposit" value={currency(equity.deposit)} />
@@ -3597,40 +3597,6 @@ export default function App() {
 
             
 
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div
-                className={`flex items-center justify-between gap-3 ${
-                  collapsedSections.cashflowDetail ? '' : 'mb-2'
-                }`}
-              >
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('cashflowDetail')}
-                    aria-expanded={!collapsedSections.cashflowDetail}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.cashflowDetail ? 'Show cash flow table' : 'Hide cash flow table'}
-                  >
-                    {collapsedSections.cashflowDetail ? '+' : '−'}
-                  </button>
-                  <SectionTitle label="Annual cash flow detail" className="text-sm font-semibold text-slate-700" />
-                </div>
-              </div>
-              {!collapsedSections.cashflowDetail ? (
-                <>
-                  <p className="mb-2 text-[11px] text-slate-500">Per-year performance through exit.</p>
-                  <CashflowTable
-                    rows={cashflowTableRows}
-                    columns={selectedCashflowColumns}
-                    hiddenColumns={hiddenCashflowColumns}
-                    onRemoveColumn={handleRemoveCashflowColumn}
-                    onAddColumn={handleAddCashflowColumn}
-                    onExport={handleExportCashflowCsv}
-                  />
-                </>
-              ) : null}
-            </div>
-
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
               <div className="order-1 md:order-1">
                 <SummaryCard title={`At exit (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exit}>
@@ -3647,14 +3613,7 @@ export default function App() {
                 </SummaryCard>
               </div>
 
-              <div className="order-3 md:order-2">
-                <SummaryCard title={`NPV (${inputs.exitYear}-yr cashflows)`} tooltip={SECTION_DESCRIPTIONS.npv}>
-                  <Line label="Discount rate" value={formatPercent(inputs.discountRate)} />
-                  <Line label="NPV" value={currency(equity.npv)} bold />
-                </SummaryCard>
-              </div>
-
-              <div className="order-2 md:order-3 md:col-span-2">
+              <div className="order-2 md:order-2">
                 <SummaryCard title={`Exit comparison (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exitComparison}>
                   <Line label="Index fund value" value={currency(equity.indexValEnd)} tooltip={indexFundTooltip} />
                   <Line
@@ -3682,66 +3641,6 @@ export default function App() {
                   </div>
                 </SummaryCard>
               </div>
-            </div>
-
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('interestSplit')}
-                    aria-expanded={!collapsedSections.interestSplit}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.interestSplit ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.interestSplit ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Interest vs principal split"
-                    tooltip={SECTION_DESCRIPTIONS.interestSplit}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-              </div>
-              {!collapsedSections.interestSplit ? (
-                <div className="h-72 w-full">
-                  {hasInterestSplitData ? (
-                    <ResponsiveContainer>
-                      <AreaChart data={interestSplitChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 11, fill: '#475569' }} />
-                        <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 11, fill: '#475569' }} width={110} />
-                        <Tooltip formatter={(value) => currency(value)} labelFormatter={(label) => `Year ${label}`} />
-                        <Legend />
-                        <Area
-                          type="monotone"
-                          dataKey="interestPaid"
-                          name="Interest"
-                          stackId="payments"
-                          stroke="#f97316"
-                          fill="rgba(249,115,22,0.25)"
-                          strokeWidth={2}
-                          isAnimationActive={false}
-                        />
-                        <Area
-                          type="monotone"
-                          dataKey="principalPaid"
-                          name="Principal"
-                          stackId="payments"
-                          stroke="#22c55e"
-                          fill="rgba(34,197,94,0.3)"
-                          strokeWidth={2}
-                          isAnimationActive={false}
-                        />
-                      </AreaChart>
-                    </ResponsiveContainer>
-                  ) : (
-                    <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 px-4 text-center text-[11px] text-slate-500">
-                      Adjust the mortgage assumptions to model interest and principal payments.
-                    </div>
-                  )}
-                </div>
-              ) : null}
             </div>
 
             <div className="rounded-2xl bg-white p-3 shadow-sm">
@@ -3877,6 +3776,66 @@ export default function App() {
                     </ResponsiveContainer>
                   </div>
                 </>
+              ) : null}
+            </div>
+
+            <div className="rounded-2xl bg-white p-3 shadow-sm">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleSection('interestSplit')}
+                    aria-expanded={!collapsedSections.interestSplit}
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                    aria-label={collapsedSections.interestSplit ? 'Show chart' : 'Hide chart'}
+                  >
+                    {collapsedSections.interestSplit ? '+' : '−'}
+                  </button>
+                  <SectionTitle
+                    label="Interest vs principal split"
+                    tooltip={SECTION_DESCRIPTIONS.interestSplit}
+                    className="text-sm font-semibold text-slate-700"
+                  />
+                </div>
+              </div>
+              {!collapsedSections.interestSplit ? (
+                <div className="h-72 w-full">
+                  {hasInterestSplitData ? (
+                    <ResponsiveContainer>
+                      <AreaChart data={interestSplitChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 11, fill: '#475569' }} />
+                        <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 11, fill: '#475569' }} width={110} />
+                        <Tooltip formatter={(value) => currency(value)} labelFormatter={(label) => `Year ${label}`} />
+                        <Legend />
+                        <Area
+                          type="monotone"
+                          dataKey="interestPaid"
+                          name="Interest"
+                          stackId="payments"
+                          stroke="#f97316"
+                          fill="rgba(249,115,22,0.25)"
+                          strokeWidth={2}
+                          isAnimationActive={false}
+                        />
+                        <Area
+                          type="monotone"
+                          dataKey="principalPaid"
+                          name="Principal"
+                          stackId="payments"
+                          stroke="#22c55e"
+                          fill="rgba(34,197,94,0.3)"
+                          strokeWidth={2}
+                          isAnimationActive={false}
+                        />
+                      </AreaChart>
+                    </ResponsiveContainer>
+                  ) : (
+                    <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 px-4 text-center text-[11px] text-slate-500">
+                      Adjust the mortgage assumptions to model interest and principal payments.
+                    </div>
+                  )}
+                </div>
               ) : null}
             </div>
 
@@ -4331,6 +4290,40 @@ export default function App() {
               ) : null}
             </div>
 
+            <div className="rounded-2xl bg-white p-3 shadow-sm">
+              <div
+                className={`flex items-center justify-between gap-3 ${
+                  collapsedSections.cashflowDetail ? '' : 'mb-2'
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleSection('cashflowDetail')}
+                    aria-expanded={!collapsedSections.cashflowDetail}
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                    aria-label={collapsedSections.cashflowDetail ? 'Show cash flow table' : 'Hide cash flow table'}
+                  >
+                    {collapsedSections.cashflowDetail ? '+' : '−'}
+                  </button>
+                  <SectionTitle label="Annual cash flow detail" className="text-sm font-semibold text-slate-700" />
+                </div>
+              </div>
+              {!collapsedSections.cashflowDetail ? (
+                <>
+                  <p className="mb-2 text-[11px] text-slate-500">Per-year performance through exit.</p>
+                  <CashflowTable
+                    rows={cashflowTableRows}
+                    columns={selectedCashflowColumns}
+                    hiddenColumns={hiddenCashflowColumns}
+                    onRemoveColumn={handleRemoveCashflowColumn}
+                    onAddColumn={handleAddCashflowColumn}
+                    onExport={handleExportCashflowCsv}
+                  />
+                </>
+              ) : null}
+            </div>
+
 
 
 
@@ -4498,6 +4491,7 @@ export default function App() {
               </div>
             ) : null}
           </div>
+
         </section>
 
         {showListingPreview ? (
@@ -4970,6 +4964,83 @@ export default function App() {
                 </div>
               </div>
             </div>
+            <aside className="w-full border-t border-slate-200 bg-slate-50 text-xs text-slate-600 md:w-80 md:border-l md:border-t-0">
+              <div className="h-full overflow-y-auto p-5 space-y-6">
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-700">Deal levers</h3>
+                  <div className="mt-3 space-y-3">
+                    {moneyInput('purchasePrice', 'Purchase price (£)', 1000)}
+                    {pctInput('depositPct', 'Deposit %')}
+                    {smallInput('exitYear', 'Exit year', 1)}
+                  </div>
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-700">Loan profile</h3>
+                  <div className="mt-3 space-y-3">
+                    {pctInput('interestRate', 'Interest rate (APR) %', 0.001)}
+                    {smallInput('mortgageYears', 'Mortgage term (years)')}
+                    <div className="rounded-xl border border-slate-200 bg-white p-3">
+                      <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">Loan type</div>
+                      <div className="mt-3 space-y-2 text-[11px] text-slate-600">
+                        <label className="flex items-center justify-between gap-3">
+                          <span className="text-slate-700">Capital repayment</span>
+                          <input
+                            type="radio"
+                            name="modal-loan-type"
+                            checked={inputs.loanType === 'repayment'}
+                            onChange={() => setInputs((s) => ({ ...s, loanType: 'repayment' }))}
+                          />
+                        </label>
+                        <label className="flex items-center justify-between gap-3">
+                          <span className="text-slate-700">Interest-only</span>
+                          <input
+                            type="radio"
+                            name="modal-loan-type"
+                            checked={inputs.loanType === 'interest_only'}
+                            onChange={() => setInputs((s) => ({ ...s, loanType: 'interest_only' }))}
+                          />
+                        </label>
+                        <p className="text-[10px] text-slate-500">
+                          Interest-only keeps the balance level; repayment shifts cash flow toward principal over time.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-700">Rent & growth</h3>
+                  <div className="mt-3 space-y-3">
+                    {moneyInput('monthlyRent', 'Monthly rent (£)', 50)}
+                    {pctInput('rentGrowth', 'Rent growth %')}
+                    {pctInput('annualAppreciation', 'Capital growth %')}
+                  </div>
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-700">Cash flow options</h3>
+                  <div className="mt-3 space-y-3">
+                    <label className="flex items-start gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-[11px] text-slate-600">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(inputs.reinvestIncome)}
+                        onChange={(event) =>
+                          setInputs((prev) => ({
+                            ...prev,
+                            reinvestIncome: event.target.checked,
+                          }))
+                        }
+                      />
+                      <span className="flex-1">
+                        <span className="block font-semibold text-slate-700">Reinvest after-tax cash flow</span>
+                        <span className="mt-1 block text-[11px] text-slate-500">
+                          Compound positive cash flow alongside the index fund path.
+                        </span>
+                      </span>
+                    </label>
+                    {inputs.reinvestIncome ? pctInput('reinvestPct', 'Reinvest % of after-tax cash flow') : null}
+                  </div>
+                </div>
+              </div>
+            </aside>
           </div>
         </div>
       </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -863,7 +863,7 @@ function calculateEquity(rawInputs) {
 
   const bridgingEnabled = Boolean(inputs.useBridgingLoan);
   const rawBridgingTerm = Number(inputs.bridgingLoanTermMonths ?? 0);
-  const bridgingTermMonths =
+  const bridgingLoanTermMonths =
     bridgingEnabled && Number.isFinite(rawBridgingTerm)
       ? Math.max(0, Math.round(rawBridgingTerm))
       : 0;
@@ -922,8 +922,8 @@ function calculateEquity(rawInputs) {
     annualPrincipal[yearIndex] += principalPaid;
   }
 
-  if (bridgingEnabled && bridgingAmount > 0 && bridgingTermMonths > 0) {
-    const monthsToModel = Math.min(bridgingTermMonths, inputs.exitYear * 12);
+  if (bridgingEnabled && bridgingAmount > 0 && bridgingLoanTermMonths > 0) {
+    const monthsToModel = Math.min(bridgingLoanTermMonths, inputs.exitYear * 12);
     const bridgingMonthlyRate = bridgingRate / 12;
     const monthlyInterest = bridgingMonthlyRate > 0 ? bridgingAmount * bridgingMonthlyRate : 0;
     for (let month = 1; month <= monthsToModel; month++) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -293,7 +293,7 @@ const DEFAULT_INPUTS = {
   loanType: 'repayment',
   useBridgingLoan: false,
   bridgingLoanTermMonths: 12,
-  bridgingLoanInterestRate: 0.08,
+  bridgingLoanInterestRate: 0.008,
   monthlyRent: 800,
   vacancyPct: 0.05,
   mgmtPct: 0.1,
@@ -868,7 +868,9 @@ function calculateEquity(rawInputs) {
       ? Math.max(0, Math.round(rawBridgingTerm))
       : 0;
   const rawBridgingRate = Number(inputs.bridgingLoanInterestRate ?? 0);
-  const bridgingRate =
+  // Bridging lenders typically quote monthly interest rates, so we treat the
+  // stored percentage as a per-month decimal.
+  const bridgingMonthlyRate =
     bridgingEnabled && Number.isFinite(rawBridgingRate)
       ? Math.max(0, rawBridgingRate)
       : 0;
@@ -926,8 +928,8 @@ function calculateEquity(rawInputs) {
 
   if (bridgingEnabled && bridgingAmount > 0 && bridgingLoanTermMonths > 0) {
     const monthsToModel = Math.min(bridgingLoanTermMonths, inputs.exitYear * 12);
-    const bridgingMonthlyRate = bridgingRate / 12;
-    const monthlyInterest = bridgingMonthlyRate > 0 ? bridgingAmount * bridgingMonthlyRate : 0;
+    const monthlyInterest =
+      bridgingMonthlyRate > 0 ? bridgingAmount * bridgingMonthlyRate : 0;
     for (let month = 1; month <= monthsToModel; month++) {
       const yearIndex = Math.ceil(month / 12) - 1;
       if (yearIndex < 0 || yearIndex >= annualDebtService.length) {
@@ -1050,7 +1052,7 @@ function calculateEquity(rawInputs) {
       totalCashRequired,
       bridgingLoanAmount: bridgingAmount,
       bridgingLoanTermMonths,
-      bridgingLoanInterestRate: bridgingRate,
+      bridgingLoanInterestRate: bridgingMonthlyRate,
       initialOutlay,
       yearly: {
         gross: 0,
@@ -1290,7 +1292,7 @@ function calculateEquity(rawInputs) {
     totalCashRequired,
     bridgingLoanAmount: bridgingAmount,
     bridgingLoanTermMonths,
-    bridgingLoanInterestRate: bridgingRate,
+    bridgingLoanInterestRate: bridgingMonthlyRate,
     projectCost,
     yoc: noiYear1 / (inputs.purchasePrice + closing + inputs.renovationCost),
     indexValEnd: indexVal,
@@ -3938,7 +3940,7 @@ export default function App() {
                     {inputs.useBridgingLoan ? (
                       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                         {smallInput('bridgingLoanTermMonths', 'Bridging term (months)')}
-                        {pctInput('bridgingLoanInterestRate', 'Bridging rate %', 0.001)}
+                        {pctInput('bridgingLoanInterestRate', 'Bridging rate (monthly) %', 0.001)}
                       </div>
                     ) : null}
                     {inputs.useBridgingLoan ? (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3965,6 +3965,7 @@ export default function App() {
                               stroke="#334155"
                               strokeDasharray="4 4"
                               strokeWidth={1}
+                              yAxisId="currency"
                             />
                           ) : null}
                           {chartFocus && chartFocus.data

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -253,14 +253,14 @@ const normalizeScenarioList = (list) =>
 const DEFAULT_INPUTS = {
   propertyAddress: '',
   propertyUrl: '',
-  purchasePrice: 250000,
+  purchasePrice: 70000,
   depositPct: 0.25,
   closingCostsPct: 0.01,
   renovationCost: 0,
   interestRate: 0.055,
   mortgageYears: 30,
   loanType: 'repayment',
-  monthlyRent: 1400,
+  monthlyRent: 800,
   vacancyPct: 0.05,
   mgmtPct: 0.1,
   repairsPct: 0.08,
@@ -268,7 +268,7 @@ const DEFAULT_INPUTS = {
   otherOpexPerYear: 300,
   annualAppreciation: 0.03,
   rentGrowth: 0.02,
-  exitYear: 10,
+  exitYear: 20,
   sellingCostsPct: 0.02,
   discountRate: 0.07,
   buyerType: 'individual',
@@ -1283,10 +1283,10 @@ export default function App() {
     rentalCashflow: false,
     cashflowDetail: false,
     wealthTrajectory: false,
-    rateTrends: false,
-    cashflowBars: false,
-    roiHeatmap: false,
-    equityGrowth: false,
+    rateTrends: true,
+    cashflowBars: true,
+    roiHeatmap: true,
+    equityGrowth: true,
   });
   const [cashflowColumnKeys, setCashflowColumnKeys] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -3558,137 +3558,7 @@ export default function App() {
               </SummaryCard>
             </div>
 
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('rateTrends')}
-                    aria-expanded={!collapsedSections.rateTrends}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.rateTrends ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.rateTrends ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Return ratios over time"
-                    tooltip={SECTION_DESCRIPTIONS.rateTrends}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-                {!collapsedSections.rateTrends ? (
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setRateChartRange({ start: 0, end: maxChartYear });
-                        setRateRangeTouched(false);
-                      }}
-                      className="hidden items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100 sm:inline-flex"
-                    >
-                      Reset range
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setShowRatesModal(true)}
-                      className="no-print inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    >
-                      Expand chart
-                    </button>
-                  </div>
-                ) : null}
-              </div>
-              {!collapsedSections.rateTrends ? (
-                <>
-                  <div className="mb-2 flex flex-wrap items-center justify-between gap-3 text-[11px] text-slate-500">
-                    <span>
-                      Years {rateChartRange.start} – {rateChartRange.end}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setRateChartRange({ start: 0, end: maxChartYear });
-                        setRateRangeTouched(false);
-                      }}
-                      className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-100 sm:hidden"
-                    >
-                      Reset range
-                    </button>
-                  </div>
-                  <div className="h-72 w-full">
-                    {rateChartDataWithMovingAverage.length > 0 ? (
-                      <ResponsiveContainer>
-                        <LineChart data={rateChartDataWithMovingAverage} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis
-                            dataKey="year"
-                            tickFormatter={(t) => `Y${t}`}
-                            tick={{ fontSize: 10, fill: '#475569' }}
-                          />
-                          <YAxis
-                            yAxisId="percent"
-                            tickFormatter={(v) => formatPercent(v)}
-                            tick={{ fontSize: 10, fill: '#475569' }}
-                            width={70}
-                          />
-                          <Tooltip formatter={(value) => formatPercent(value)} labelFormatter={(label) => `Year ${label}`} />
-                          <Legend
-                            content={(props) => (
-                              <ChartLegend
-                                {...props}
-                                activeSeries={rateSeriesActive}
-                                onToggle={toggleRateSeries}
-                                excludedKeys={RATE_SERIES_KEYS.map((key) => `${key}MA`)}
-                              />
-                            )}
-                          />
-                          {rateChartSettings.showZeroBaseline ? (
-                            <ReferenceLine y={0} yAxisId="percent" stroke="#cbd5f5" strokeDasharray="4 4" />
-                          ) : null}
-                          {RATE_SERIES_KEYS.map((key) => (
-                            <RechartsLine
-                              key={key}
-                              type="monotone"
-                              dataKey={key}
-                              name={SERIES_LABELS[key] ?? key}
-                              stroke={SERIES_COLORS[key]}
-                              strokeWidth={2}
-                              dot={false}
-                              yAxisId="percent"
-                              hide={!rateSeriesActive[key]}
-                            />
-                          ))}
-                          {rateChartSettings.showMovingAverage
-                            ? RATE_SERIES_KEYS.map((key) => (
-                                <RechartsLine
-                                  key={`${key}MA`}
-                                  type="monotone"
-                                  dataKey={`${key}MA`}
-                                  stroke={SERIES_COLORS[key]}
-                                  strokeWidth={1.5}
-                                  strokeDasharray="4 3"
-                                  dot={false}
-                                  yAxisId="percent"
-                                  hide={!rateSeriesActive[key]}
-                                  legendType="none"
-                                  isAnimationActive={false}
-                                  strokeOpacity={0.6}
-                                />
-                              ))
-                            : null}
-                        </LineChart>
-                      </ResponsiveContainer>
-                    ) : (
-                      <div className="flex h-full items-center justify-center text-center text-[11px] text-slate-500">
-                        Not enough data to plot return ratios yet.
-                      </div>
-                    )}
-                  </div>
-                </>
-              ) : (
-                <div className="text-[11px] text-slate-500">Chart hidden. Select “+” to display it.</div>
-              )}
-            </div>
+            
 
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
               <SummaryCard title={`At exit (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exit}>
@@ -3843,9 +3713,203 @@ export default function App() {
                     </ResponsiveContainer>
                   </div>
                 </>
-              ) : (
-                <div className="text-[11px] text-slate-500">Chart hidden. Select “+” to display it.</div>
-              )}
+              ) : null}
+            </div>
+
+            <div className="rounded-2xl bg-white p-3 shadow-sm">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleSection('rateTrends')}
+                    aria-expanded={!collapsedSections.rateTrends}
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                    aria-label={collapsedSections.rateTrends ? 'Show chart' : 'Hide chart'}
+                  >
+                    {collapsedSections.rateTrends ? '+' : '−'}
+                  </button>
+                  <SectionTitle
+                    label="Return ratios over time"
+                    tooltip={SECTION_DESCRIPTIONS.rateTrends}
+                    className="text-sm font-semibold text-slate-700"
+                  />
+                </div>
+                {!collapsedSections.rateTrends ? (
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setRateChartRange({ start: 0, end: maxChartYear });
+                        setRateRangeTouched(false);
+                      }}
+                      className="hidden items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100 sm:inline-flex"
+                    >
+                      Reset range
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowRatesModal(true)}
+                      className="no-print inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                    >
+                      Expand chart
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+              {!collapsedSections.rateTrends ? (
+                <>
+                  <div className="mb-2 flex flex-wrap items-center justify-between gap-3 text-[11px] text-slate-500">
+                    <span>
+                      Years {rateChartRange.start} – {rateChartRange.end}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setRateChartRange({ start: 0, end: maxChartYear });
+                        setRateRangeTouched(false);
+                      }}
+                      className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-100 sm:hidden"
+                    >
+                      Reset range
+                    </button>
+                  </div>
+                  <div className="h-72 w-full">
+                    {rateChartDataWithMovingAverage.length > 0 ? (
+                      <ResponsiveContainer>
+                        <LineChart data={rateChartDataWithMovingAverage} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                          <CartesianGrid strokeDasharray="3 3" />
+                          <XAxis
+                            dataKey="year"
+                            tickFormatter={(t) => `Y${t}`}
+                            tick={{ fontSize: 10, fill: '#475569' }}
+                          />
+                          <YAxis
+                            yAxisId="percent"
+                            tickFormatter={(v) => formatPercent(v)}
+                            tick={{ fontSize: 10, fill: '#475569' }}
+                            width={70}
+                          />
+                          <Tooltip formatter={(value) => formatPercent(value)} labelFormatter={(label) => `Year ${label}`} />
+                          <Legend
+                            content={(props) => (
+                              <ChartLegend
+                                {...props}
+                                activeSeries={rateSeriesActive}
+                                onToggle={toggleRateSeries}
+                                excludedKeys={RATE_SERIES_KEYS.map((key) => `${key}MA`)}
+                              />
+                            )}
+                          />
+                          {rateChartSettings.showZeroBaseline ? (
+                            <ReferenceLine y={0} yAxisId="percent" stroke="#cbd5f5" strokeDasharray="4 4" />
+                          ) : null}
+                          {RATE_SERIES_KEYS.map((key) => (
+                            <RechartsLine
+                              key={key}
+                              type="monotone"
+                              dataKey={key}
+                              name={SERIES_LABELS[key] ?? key}
+                              stroke={SERIES_COLORS[key]}
+                              strokeWidth={2}
+                              dot={false}
+                              yAxisId="percent"
+                              hide={!rateSeriesActive[key]}
+                            />
+                          ))}
+                          {rateChartSettings.showMovingAverage
+                            ? RATE_SERIES_KEYS.map((key) => (
+                                <RechartsLine
+                                  key={`${key}MA`}
+                                  type="monotone"
+                                  dataKey={`${key}MA`}
+                                  stroke={SERIES_COLORS[key]}
+                                  strokeWidth={1.5}
+                                  strokeDasharray="4 3"
+                                  dot={false}
+                                  yAxisId="percent"
+                                  hide={!rateSeriesActive[key]}
+                                  legendType="none"
+                                  isAnimationActive={false}
+                                  strokeOpacity={0.6}
+                                />
+                              ))
+                            : null}
+                        </LineChart>
+                      </ResponsiveContainer>
+                    ) : (
+                      <div className="flex h-full items-center justify-center text-center text-[11px] text-slate-500">
+                        Not enough data to plot return ratios yet.
+                      </div>
+                    )}
+                  </div>
+                </>
+              ) : null}
+            </div>
+
+            <div className="rounded-2xl bg-white p-3 shadow-sm">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleSection('equityGrowth')}
+                    aria-expanded={!collapsedSections.equityGrowth}
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                    aria-label={collapsedSections.equityGrowth ? 'Show chart' : 'Hide chart'}
+                  >
+                    {collapsedSections.equityGrowth ? '+' : '−'}
+                  </button>
+                  <SectionTitle
+                    label="Equity growth over time"
+                    tooltip={SECTION_DESCRIPTIONS.equityGrowth}
+                    className="text-sm font-semibold text-slate-700"
+                  />
+                </div>
+              </div>
+              {!collapsedSections.equityGrowth ? (
+                <>
+                  <p className="mb-2 text-[11px] text-slate-500">
+                    See how outstanding debt compares with the portion you own as the property appreciates and the mortgage is repaid.
+                  </p>
+                  <div className="h-72 w-full">
+                    {equityGrowthChartData.length > 0 ? (
+                      <ResponsiveContainer>
+                        <AreaChart data={equityGrowthChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                          <CartesianGrid strokeDasharray="3 3" />
+                          <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 10, fill: '#475569' }} />
+                          <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 10, fill: '#475569' }} width={100} />
+                          <Tooltip
+                            formatter={(value, name) => currency(value)}
+                            labelFormatter={(label) => `Year ${label}`}
+                          />
+                          <Legend />
+                          <Area
+                            type="monotone"
+                            dataKey="loanBalance"
+                            name="Lender share"
+                            stackId="equity"
+                            stroke="#94a3b8"
+                            fill="rgba(148,163,184,0.4)"
+                            isAnimationActive={false}
+                          />
+                          <Area
+                            type="monotone"
+                            dataKey="ownerEquity"
+                            name="Your equity"
+                            stackId="equity"
+                            stroke="#10b981"
+                            fill="rgba(16,185,129,0.35)"
+                            isAnimationActive={false}
+                          />
+                        </AreaChart>
+                      </ResponsiveContainer>
+                    ) : (
+                      <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 text-center text-[11px] text-slate-500">
+                        Equity projections will appear once an exit year and loan details are provided.
+                      </div>
+                    )}
+                  </div>
+                </>
+              ) : null}
             </div>
 
             <div className="rounded-2xl bg-white p-3 shadow-sm">
@@ -3927,9 +3991,7 @@ export default function App() {
                     )}
                   </div>
                 </>
-              ) : (
-                <div className="text-[11px] text-slate-500">Chart hidden. Select “+” to display it.</div>
-              )}
+              ) : null}
             </div>
 
             <div className="rounded-2xl bg-white p-3 shadow-sm">
@@ -4006,7 +4068,7 @@ export default function App() {
                                       <div
                                         className="rounded-lg px-2 py-3 text-center text-xs font-semibold text-slate-800"
                                         style={{ backgroundColor: background }}
-                                        title={`${formatPercent(cell.irr)} IRR | ${formatPercent(cell.roi)} total ROI`}
+                                        title={`If rent yield is ${formatPercent(cell.yieldRate)} and capital growth is ${formatPercent(row.growthRate)}, expect ${formatPercent(value)} ${roiHeatmapMetric === 'irr' ? 'IRR' : 'total ROI'} (IRR ${formatPercent(cell.irr)}, total ROI ${formatPercent(cell.roi)}).`}
                                       >
                                         {formatPercent(value)}
                                       </div>
@@ -4025,78 +4087,26 @@ export default function App() {
                     )}
                   </div>
                 </>
-              ) : (
-                <div className="text-[11px] text-slate-500">Heatmap hidden. Select “+” to display it.</div>
-              )}
+              ) : null}
             </div>
 
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('equityGrowth')}
-                    aria-expanded={!collapsedSections.equityGrowth}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.equityGrowth ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.equityGrowth ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Equity growth over time"
-                    tooltip={SECTION_DESCRIPTIONS.equityGrowth}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-              </div>
-              {!collapsedSections.equityGrowth ? (
-                <>
-                  <p className="mb-2 text-[11px] text-slate-500">
-                    See how outstanding debt compares with the portion you own as the property appreciates and the mortgage is repaid.
-                  </p>
-                  <div className="h-72 w-full">
-                    {equityGrowthChartData.length > 0 ? (
-                      <ResponsiveContainer>
-                        <AreaChart data={equityGrowthChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis dataKey="year" tickFormatter={(value) => `Y${value}`} tick={{ fontSize: 10, fill: '#475569' }} />
-                          <YAxis tickFormatter={(value) => currency(value)} tick={{ fontSize: 10, fill: '#475569' }} width={100} />
-                          <Tooltip
-                            formatter={(value, name) => currency(value)}
-                            labelFormatter={(label) => `Year ${label}`}
-                          />
-                          <Legend />
-                          <Area
-                            type="monotone"
-                            dataKey="loanBalance"
-                            name="Lender share"
-                            stackId="equity"
-                            stroke="#94a3b8"
-                            fill="rgba(148,163,184,0.4)"
-                            isAnimationActive={false}
-                          />
-                          <Area
-                            type="monotone"
-                            dataKey="ownerEquity"
-                            name="Your equity"
-                            stackId="equity"
-                            stroke="#10b981"
-                            fill="rgba(16,185,129,0.35)"
-                            isAnimationActive={false}
-                          />
-                        </AreaChart>
-                      </ResponsiveContainer>
-                    ) : (
-                      <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 text-center text-[11px] text-slate-500">
-                        Equity projections will appear once an exit year and loan details are provided.
-                      </div>
-                    )}
-                  </div>
-                </>
-              ) : (
-                <div className="text-[11px] text-slate-500">Chart hidden. Select “+” to display it.</div>
-              )}
-            </div>
+
+
+
+
+
+
+
+
+
+
+            
+
+            
+
+            
+
+            
 
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
               <div className="space-y-3 md:order-2 md:col-span-1">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import {
   CartesianGrid,
   ReferenceLine,
   ReferenceDot,
+  ReferenceArea,
   Line as RechartsLine,
 } from 'recharts';
 import html2canvas from 'html2canvas';
@@ -124,6 +125,8 @@ const HEATMAP_COLOR_NEUTRAL = [148, 163, 184];
 const LEVERAGE_LTV_OPTIONS = Array.from({ length: 18 }, (_, index) =>
   Number((0.1 + index * 0.05).toFixed(2))
 );
+const LEVERAGE_SAFE_MAX_LTV = 0.75;
+const LEVERAGE_MAX_LTV = LEVERAGE_LTV_OPTIONS[LEVERAGE_LTV_OPTIONS.length - 1];
 
 const EXPANDED_SERIES_ORDER = [
   'indexFund',
@@ -4516,6 +4519,18 @@ export default function App() {
                                   />
                                 )}
                               />
+                              {LEVERAGE_MAX_LTV > LEVERAGE_SAFE_MAX_LTV ? (
+                                <ReferenceArea
+                                  x1={LEVERAGE_SAFE_MAX_LTV}
+                                  x2={LEVERAGE_MAX_LTV}
+                                  yAxisId="left"
+                                  y1="dataMin"
+                                  y2="dataMax"
+                                  strokeOpacity={0}
+                                  fill="#f1f5f9"
+                                  fillOpacity={0.35}
+                                />
+                              ) : null}
                               <RechartsLine
                                 type="monotone"
                                 dataKey="irr"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,7 +107,7 @@ const ROI_HEATMAP_YIELD_OPTIONS = [0.04, 0.05, 0.06, 0.07, 0.08];
 const HEATMAP_COLOR_START = [248, 113, 113];
 const HEATMAP_COLOR_END = [34, 197, 94];
 const HEATMAP_COLOR_NEUTRAL = [148, 163, 184];
-const LEVERAGE_LTV_OPTIONS = [0.5, 0.6, 0.7, 0.75, 0.8, 0.85, 0.9];
+const LEVERAGE_LTV_OPTIONS = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75];
 
 const EXPANDED_SERIES_ORDER = [
   'indexFund',
@@ -379,8 +379,6 @@ const SECTION_DESCRIPTIONS = {
     'Track cap rate, yield on cost, cash-on-cash, and IRR across the hold period to compare return profiles over time.',
   exitComparison:
     'Compares exit-year totals for the property and the index fund, including after-tax wealth and cumulative rental tax.',
-  sensitivity:
-    'Adjust the rent sensitivity to see how Year 1 after-tax cash flow shifts when rents move up or down.',
   cashflowBars:
     'Visualises annual rent, expenses, debt service, and after-tax cash flow to highlight lean years or sudden swings.',
   roiHeatmap:
@@ -1372,7 +1370,6 @@ export default function App() {
     showZeroBaseline: true,
   });
   const [performanceYear, setPerformanceYear] = useState(1);
-  const [sensitivityPct, setSensitivityPct] = useState(0.1);
   const [shareNotice, setShareNotice] = useState('');
   const [isChatOpen, setIsChatOpen] = useState(false);
   const pageRef = useRef(null);
@@ -2847,31 +2844,6 @@ export default function App() {
     </div>
   );
 
-  const sensitivityResults = useMemo(() => {
-    const rent = Number.isFinite(inputs.monthlyRent) ? inputs.monthlyRent : 0;
-    const scenarioBase = equity.cashflowYear1AfterTax;
-    const evaluate = (multiplier) => {
-      const adjustedRent = Math.max(0, roundTo(rent * multiplier, 2));
-      return calculateEquity({ ...inputs, monthlyRent: adjustedRent }).cashflowYear1AfterTax;
-    };
-    const downMultiplier = clamp(1 - sensitivityPct, 0, 2);
-    const upMultiplier = Math.max(0, 1 + sensitivityPct);
-    return {
-      base: scenarioBase,
-      down: evaluate(downMultiplier),
-      up: evaluate(upMultiplier),
-    };
-  }, [equity.cashflowYear1AfterTax, inputs, sensitivityPct]);
-  const sensitivityPercentLabel = `${roundTo(sensitivityPct * 100, 2)}%`;
-  const canDecreaseSensitivity = sensitivityPct > 0;
-  const canIncreaseSensitivity = sensitivityPct < 0.5;
-  const handleAdjustSensitivity = (delta) => {
-    setSensitivityPct((current) => {
-      const next = clamp(roundTo(current + delta, 3), 0, 0.5);
-      return next;
-    });
-  };
-
   const integrateScenario = (record, { select = false } = {}) => {
     const normalized = normalizeScenarioRecord(record);
     if (!normalized) return null;
@@ -3324,20 +3296,18 @@ export default function App() {
           </header>
         </div>
 
-        <main className="py-6">
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-3 md:items-start">
-            <section className="md:col-span-1 md:self-start">
-              <div className="md:sticky md:top-28">
-                <div className="md:max-h-[calc(100vh-8rem)] md:overflow-y-auto md:pr-2 md:pb-4">
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <h2 className="mb-2 text-base font-semibold">Deal Inputs</h2>
+        <main className="py-6 md:min-h-screen">
+          <div className="grid grid-cols-1 gap-4 md:min-h-[calc(100vh-8rem)] md:grid-cols-3 md:items-stretch">
+            <section className="space-y-3 md:col-span-1 md:self-start md:pr-2 md:pb-4">
+              <div className="rounded-2xl bg-white p-3 shadow-sm">
+                <h2 className="mb-2 text-base font-semibold">Deal Inputs</h2>
 
-              <CollapsibleSection
-                title="Property info"
-                collapsed={collapsedSections.propertyInfo}
-                onToggle={() => toggleSection('propertyInfo')}
-              >
-                <div className="grid gap-2 md:grid-cols-2">
+                <CollapsibleSection
+                  title="Property info"
+                  collapsed={collapsedSections.propertyInfo}
+                  onToggle={() => toggleSection('propertyInfo')}
+                >
+                  <div className="grid gap-2 md:grid-cols-2">
                   <div className="md:col-span-2">{textInput('propertyAddress', 'Property address')}</div>
                   <div className="flex flex-col gap-1 md:col-span-2">
                     <label className="text-xs font-medium text-slate-600">Property URL</label>
@@ -3408,14 +3378,14 @@ export default function App() {
                   {previewLoading ? <div>Loading preview…</div> : null}
                   {previewError ? <div className="text-rose-600">{previewError}</div> : null}
                 </div>
-              </CollapsibleSection>
+                </CollapsibleSection>
 
-              <CollapsibleSection
-                title="Buyer profile"
-                collapsed={collapsedSections.buyerProfile}
-                onToggle={() => toggleSection('buyerProfile')}
-              >
-                <div className="flex items-center gap-3 text-xs">
+                <CollapsibleSection
+                  title="Buyer profile"
+                  collapsed={collapsedSections.buyerProfile}
+                  onToggle={() => toggleSection('buyerProfile')}
+                >
+                  <div className="flex items-center gap-3 text-xs">
                   <label className="inline-flex items-center gap-2">
                     <input
                       type="radio"
@@ -3459,14 +3429,14 @@ export default function App() {
                     Company purchases are treated here at higher rates (+5% surcharge on the total price).
                   </div>
                 )}
-              </CollapsibleSection>
+                </CollapsibleSection>
 
-              <CollapsibleSection
-                title="Household income"
-                collapsed={collapsedSections.householdIncome}
-                onToggle={() => toggleSection('householdIncome')}
-              >
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <CollapsibleSection
+                  title="Household income"
+                  collapsed={collapsedSections.householdIncome}
+                  onToggle={() => toggleSection('householdIncome')}
+                >
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                   {moneyInput('incomePerson1', 'Owner A income (£)', 1000)}
                   {moneyInput('incomePerson2', 'Owner B income (£)', 1000)}
                   {pctInput('ownershipShare1', 'Owner A ownership %')}
@@ -3477,14 +3447,14 @@ export default function App() {
                     ? 'For company purchases, rental profits are taxed at a flat 19% corporation tax rate. Ownership percentages still control how cash flows are split across the summary.'
                     : 'Rental profit is allocated according to the ownership percentages above before applying each owner’s marginal tax bands. Percentages are normalised if they do not sum to 100%.'}
                 </p>
-              </CollapsibleSection>
+                </CollapsibleSection>
 
-              <CollapsibleSection
-                title="Purchase costs"
-                collapsed={collapsedSections.purchaseCosts}
-                onToggle={() => toggleSection('purchaseCosts')}
-              >
-                <div className="grid grid-cols-2 gap-2">
+                <CollapsibleSection
+                  title="Purchase costs"
+                  collapsed={collapsedSections.purchaseCosts}
+                  onToggle={() => toggleSection('purchaseCosts')}
+                >
+                  <div className="grid grid-cols-2 gap-2">
                   {moneyInput('purchasePrice', 'Purchase price (£)')}
                   {pctInput('depositPct', 'Deposit %')}
                   {pctInput('closingCostsPct', 'Other closing costs %')}
@@ -3517,14 +3487,14 @@ export default function App() {
                     <div className="mt-1 text-[11px] text-slate-500">Interest‑only keeps the loan balance unchanged until exit; debt service = interest only.</div>
                   </div>
                 </div>
-              </CollapsibleSection>
+                </CollapsibleSection>
 
-              <CollapsibleSection
-                title="Rental cashflow"
-                collapsed={collapsedSections.rentalCashflow}
-                onToggle={() => toggleSection('rentalCashflow')}
-              >
-                <div className="grid grid-cols-2 gap-2">
+                <CollapsibleSection
+                  title="Rental cashflow"
+                  collapsed={collapsedSections.rentalCashflow}
+                  onToggle={() => toggleSection('rentalCashflow')}
+                >
+                  <div className="grid grid-cols-2 gap-2">
                   {moneyInput('monthlyRent', 'Monthly rent (£)', 50)}
                   {pctInput('vacancyPct', 'Vacancy %')}
                   {pctInput('mgmtPct', 'Management %')}
@@ -3561,14 +3531,13 @@ export default function App() {
                     )}
                   </div>
                 </div>
-              </CollapsibleSection>
+                </CollapsibleSection>
 
-            </div>
-          </div>
-        </div>
-      </section>
+              </div>
+            </section>
 
-      <section className="space-y-3 md:col-span-2">
+      <section className="md:col-span-2 md:self-stretch">
+        <div className="flex flex-col space-y-3 md:h-[calc(100vh-8rem)] md:min-h-[calc(100vh-8rem)] md:overflow-y-auto md:pr-2 md:pb-6">
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <SummaryCard title="Cash needed" tooltip={SECTION_DESCRIPTIONS.cashNeeded}>
                 <Line label="Deposit" value={currency(equity.deposit)} />
@@ -3629,6 +3598,93 @@ export default function App() {
             
 
             <div className="rounded-2xl bg-white p-3 shadow-sm">
+              <div
+                className={`flex items-center justify-between gap-3 ${
+                  collapsedSections.cashflowDetail ? '' : 'mb-2'
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => toggleSection('cashflowDetail')}
+                    aria-expanded={!collapsedSections.cashflowDetail}
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                    aria-label={collapsedSections.cashflowDetail ? 'Show cash flow table' : 'Hide cash flow table'}
+                  >
+                    {collapsedSections.cashflowDetail ? '+' : '−'}
+                  </button>
+                  <SectionTitle label="Annual cash flow detail" className="text-sm font-semibold text-slate-700" />
+                </div>
+              </div>
+              {!collapsedSections.cashflowDetail ? (
+                <>
+                  <p className="mb-2 text-[11px] text-slate-500">Per-year performance through exit.</p>
+                  <CashflowTable
+                    rows={cashflowTableRows}
+                    columns={selectedCashflowColumns}
+                    hiddenColumns={hiddenCashflowColumns}
+                    onRemoveColumn={handleRemoveCashflowColumn}
+                    onAddColumn={handleAddCashflowColumn}
+                    onExport={handleExportCashflowCsv}
+                  />
+                </>
+              ) : null}
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div className="order-1 md:order-1">
+                <SummaryCard title={`At exit (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exit}>
+                  <Line label="Future value" value={currency(equity.futureValue)} tooltip={futureValueTooltip} />
+                  <Line label="Remaining loan" value={currency(equity.remaining)} tooltip={remainingLoanTooltip} />
+                  <Line label="Selling costs" value={currency(equity.sellingCosts)} tooltip={sellingCostsTooltip} />
+                  <hr className="my-2" />
+                  <Line
+                    label="Estimated equity then"
+                    value={currency(estimatedExitEquity)}
+                    bold
+                    tooltip={estimatedEquityTooltip}
+                  />
+                </SummaryCard>
+              </div>
+
+              <div className="order-3 md:order-2">
+                <SummaryCard title={`NPV (${inputs.exitYear}-yr cashflows)`} tooltip={SECTION_DESCRIPTIONS.npv}>
+                  <Line label="Discount rate" value={formatPercent(inputs.discountRate)} />
+                  <Line label="NPV" value={currency(equity.npv)} bold />
+                </SummaryCard>
+              </div>
+
+              <div className="order-2 md:order-3 md:col-span-2">
+                <SummaryCard title={`Exit comparison (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exitComparison}>
+                  <Line label="Index fund value" value={currency(equity.indexValEnd)} tooltip={indexFundTooltip} />
+                  <Line
+                    label="Property gross"
+                    value={currency(equity.propertyGrossWealthAtExit)}
+                    tooltip={propertyGrossTooltip}
+                  />
+                  <Line label="Property net" value={currency(equity.propertyNetWealthAtExit)} tooltip={propertyNetTooltip} />
+                  <Line
+                    label={propertyNetAfterTaxLabel}
+                    value={currency(equity.propertyNetWealthAfterTax)}
+                    tooltip={propertyNetAfterTaxTooltip}
+                  />
+                  <Line
+                    label={rentalTaxCumulativeLabel}
+                    value={currency(equity.totalPropertyTax)}
+                    tooltip={rentalTaxTooltip}
+                  />
+                  <div className="mt-2 text-xs text-slate-600">
+                    {equity.propertyNetWealthAfterTax > equity.indexValEnd
+                      ? `${afterTaxComparisonPrefix}, property (net) still leads the index.`
+                      : equity.propertyNetWealthAfterTax < equity.indexValEnd
+                      ? `${afterTaxComparisonPrefix}, the index fund pulls ahead.`
+                      : `${afterTaxComparisonPrefix}, both paths are broadly similar.`}
+                  </div>
+                </SummaryCard>
+              </div>
+            </div>
+
+            <div className="rounded-2xl bg-white p-3 shadow-sm">
               <div className="mb-2 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                   <button
@@ -3686,101 +3742,6 @@ export default function App() {
                   )}
                 </div>
               ) : null}
-            </div>
-
-            <div className="rounded-2xl bg-white p-3 shadow-sm">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleSection('leverage')}
-                    aria-expanded={!collapsedSections.leverage}
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
-                    aria-label={collapsedSections.leverage ? 'Show chart' : 'Hide chart'}
-                  >
-                    {collapsedSections.leverage ? '+' : '−'}
-                  </button>
-                  <SectionTitle
-                    label="Leverage multiplier"
-                    tooltip={SECTION_DESCRIPTIONS.leverage}
-                    className="text-sm font-semibold text-slate-700"
-                  />
-                </div>
-              </div>
-              {!collapsedSections.leverage ? (
-                <>
-                  <p className="mb-2 text-[11px] text-slate-500">
-                    Each point recalculates the deal using the same assumptions but with a different LTV. ROI reflects net wealth at exit versus cash invested.
-                  </p>
-                  <div className="h-72 w-full">
-                    {hasLeverageData ? (
-                      <ResponsiveContainer>
-                        <LineChart data={leverageChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
-                          <CartesianGrid strokeDasharray="3 3" />
-                          <XAxis
-                            dataKey="ltv"
-                            tickFormatter={(value) => formatPercent(value)}
-                            tick={{ fontSize: 11, fill: '#475569' }}
-                          />
-                          <YAxis
-                            tickFormatter={(value) => formatPercent(value)}
-                            tick={{ fontSize: 11, fill: '#475569' }}
-                            width={90}
-                          />
-                          <Tooltip
-                            formatter={(value, key) => [formatPercent(value), key === 'irr' ? 'IRR' : 'Total ROI']}
-                            labelFormatter={(label) => `LTV ${formatPercent(label)}`}
-                          />
-                          <Legend />
-                          <RechartsLine
-                            type="monotone"
-                            dataKey="irr"
-                            name="IRR"
-                            stroke={SERIES_COLORS.irrSeries}
-                            strokeWidth={2}
-                            dot={{ r: 3 }}
-                            isAnimationActive={false}
-                          />
-                          <RechartsLine
-                            type="monotone"
-                            dataKey="roi"
-                            name="Total ROI"
-                            stroke="#0ea5e9"
-                            strokeWidth={2}
-                            strokeDasharray="4 2"
-                            dot={{ r: 3 }}
-                            isAnimationActive={false}
-                          />
-                        </LineChart>
-                      </ResponsiveContainer>
-                    ) : (
-                      <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 px-4 text-center text-[11px] text-slate-500">
-                        Enter a purchase price and rent to explore leverage outcomes.
-                      </div>
-                    )}
-                  </div>
-                </>
-              ) : null}
-            </div>
-
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-              <SummaryCard title={`At exit (Year ${inputs.exitYear})`} tooltip={SECTION_DESCRIPTIONS.exit}>
-                <Line label="Future value" value={currency(equity.futureValue)} tooltip={futureValueTooltip} />
-                <Line label="Remaining loan" value={currency(equity.remaining)} tooltip={remainingLoanTooltip} />
-                <Line label="Selling costs" value={currency(equity.sellingCosts)} tooltip={sellingCostsTooltip} />
-                <hr className="my-2" />
-                <Line
-                  label="Estimated equity then"
-                  value={currency(estimatedExitEquity)}
-                  bold
-                  tooltip={estimatedEquityTooltip}
-                />
-              </SummaryCard>
-
-              <SummaryCard title={`NPV (${inputs.exitYear}-yr cashflows)`} tooltip={SECTION_DESCRIPTIONS.npv}>
-                <Line label="Discount rate" value={formatPercent(inputs.discountRate)} />
-                <Line label="NPV" value={currency(equity.npv)} bold />
-              </SummaryCard>
             </div>
 
             <div className="rounded-2xl bg-white p-3 shadow-sm">
@@ -4202,6 +4163,83 @@ export default function App() {
                 <div className="flex items-center gap-2">
                   <button
                     type="button"
+                    onClick={() => toggleSection('leverage')}
+                    aria-expanded={!collapsedSections.leverage}
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                    aria-label={collapsedSections.leverage ? 'Show chart' : 'Hide chart'}
+                  >
+                    {collapsedSections.leverage ? '+' : '−'}
+                  </button>
+                  <SectionTitle
+                    label="Leverage multiplier"
+                    tooltip={SECTION_DESCRIPTIONS.leverage}
+                    className="text-sm font-semibold text-slate-700"
+                  />
+                </div>
+              </div>
+              {!collapsedSections.leverage ? (
+                <>
+                  <p className="mb-2 text-[11px] text-slate-500">
+                    Each point recalculates the deal using the same assumptions but with a different LTV. ROI reflects net wealth at exit versus cash invested.
+                  </p>
+                  <div className="h-72 w-full">
+                    {hasLeverageData ? (
+                      <ResponsiveContainer>
+                        <LineChart data={leverageChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                          <CartesianGrid strokeDasharray="3 3" />
+                          <XAxis
+                            dataKey="ltv"
+                            tickFormatter={(value) => formatPercent(value)}
+                            tick={{ fontSize: 11, fill: '#475569' }}
+                            domain={[0.1, 0.75]}
+                            type="number"
+                          />
+                          <YAxis
+                            tickFormatter={(value) => formatPercent(value)}
+                            tick={{ fontSize: 11, fill: '#475569' }}
+                            width={90}
+                          />
+                          <Tooltip
+                            formatter={(value, key) => [formatPercent(value), key === 'irr' ? 'IRR' : 'Total ROI']}
+                            labelFormatter={(label) => `LTV ${formatPercent(label)}`}
+                          />
+                          <Legend />
+                          <RechartsLine
+                            type="monotone"
+                            dataKey="irr"
+                            name="IRR"
+                            stroke={SERIES_COLORS.irrSeries}
+                            strokeWidth={2}
+                            dot={{ r: 3 }}
+                            isAnimationActive={false}
+                          />
+                          <RechartsLine
+                            type="monotone"
+                            dataKey="roi"
+                            name="Total ROI"
+                            stroke="#0ea5e9"
+                            strokeWidth={2}
+                            strokeDasharray="4 2"
+                            dot={{ r: 3 }}
+                            isAnimationActive={false}
+                          />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    ) : (
+                      <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-slate-200 px-4 text-center text-[11px] text-slate-500">
+                        Enter a purchase price and rent to explore leverage outcomes.
+                      </div>
+                    )}
+                  </div>
+                </>
+              ) : null}
+            </div>
+
+            <div className="rounded-2xl bg-white p-3 shadow-sm">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
                     onClick={() => toggleSection('roiHeatmap')}
                     aria-expanded={!collapsedSections.roiHeatmap}
                     className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
@@ -4311,111 +4349,8 @@ export default function App() {
 
             
 
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-              <div className="space-y-3 md:order-2 md:col-span-1">
-                <SummaryCard
-                  title={`Exit comparison (Year ${inputs.exitYear})`}
-                  tooltip={SECTION_DESCRIPTIONS.exitComparison}
-                >
-                  <Line
-                    label="Index fund value"
-                    value={currency(equity.indexValEnd)}
-                    tooltip={indexFundTooltip}
-                  />
-                  <Line
-                    label="Property gross"
-                    value={currency(equity.propertyGrossWealthAtExit)}
-                    tooltip={propertyGrossTooltip}
-                  />
-                  <Line
-                    label="Property net"
-                    value={currency(equity.propertyNetWealthAtExit)}
-                    tooltip={propertyNetTooltip}
-                  />
-                  <Line
-                    label={propertyNetAfterTaxLabel}
-                    value={currency(equity.propertyNetWealthAfterTax)}
-                    tooltip={propertyNetAfterTaxTooltip}
-                  />
-                  <Line
-                    label={rentalTaxCumulativeLabel}
-                    value={currency(equity.totalPropertyTax)}
-                    tooltip={rentalTaxTooltip}
-                  />
-                  <div className="mt-2 text-xs text-slate-600">
-                    {equity.propertyNetWealthAfterTax > equity.indexValEnd
-                      ? `${afterTaxComparisonPrefix}, property (net) still leads the index.`
-                      : equity.propertyNetWealthAfterTax < equity.indexValEnd
-                      ? `${afterTaxComparisonPrefix}, the index fund pulls ahead.`
-                      : `${afterTaxComparisonPrefix}, both paths are broadly similar.`}
-                  </div>
-                </SummaryCard>
-              </div>
-
-              <div className="md:order-1 md:col-span-1">
-                <SummaryCard
-                  title={
-                    <div className="flex items-center justify-between gap-2">
-                      <SectionTitle
-                        label="Sensitivity"
-                        tooltip={SECTION_DESCRIPTIONS.sensitivity}
-                        className="text-sm font-semibold text-slate-700"
-                      />
-                      <div className="flex items-center gap-1 text-[11px] text-slate-500">
-                        <button
-                          type="button"
-                          onClick={() => handleAdjustSensitivity(-0.01)}
-                          className="flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
-                          aria-label="Decrease rent sensitivity"
-                          disabled={!canDecreaseSensitivity}
-                        >
-                          ▼
-                        </button>
-                        <span className="min-w-[3ch] text-right font-semibold text-slate-700">
-                          {sensitivityPercentLabel}
-                        </span>
-                        <button
-                          type="button"
-                          onClick={() => handleAdjustSensitivity(0.01)}
-                          className="flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
-                          aria-label="Increase rent sensitivity"
-                          disabled={!canIncreaseSensitivity}
-                        >
-                          ▲
-                        </button>
-                      </div>
-                    </div>
-                  }
-                >
-                  <div className="space-y-0.5">
-                    <SensitivityRow label={`Rent −${sensitivityPercentLabel}`} value={sensitivityResults.down} />
-                    <SensitivityRow label="Base" value={sensitivityResults.base} />
-                    <SensitivityRow label={`Rent +${sensitivityPercentLabel}`} value={sensitivityResults.up} />
-                  </div>
-                </SummaryCard>
-              </div>
-
-              <div className="md:col-span-2 md:order-3">
-                <CollapsibleSection
-                  title="Annual cash flow detail"
-                  collapsed={collapsedSections.cashflowDetail}
-                  onToggle={() => toggleSection('cashflowDetail')}
-                  className="rounded-2xl bg-white p-3 shadow-sm"
-                >
-                  <p className="mb-2 text-[11px] text-slate-500">Per-year performance through exit.</p>
-                  <CashflowTable
-                    rows={cashflowTableRows}
-                    columns={selectedCashflowColumns}
-                    hiddenColumns={hiddenCashflowColumns}
-                    onRemoveColumn={handleRemoveCashflowColumn}
-                    onAddColumn={handleAddCashflowColumn}
-                    onExport={handleExportCashflowCsv}
-                  />
-                </CollapsibleSection>
-              </div>
-            </div>
-
-          </section>
+        </div>
+      </section>
         </div>
 
         <section className="mt-6">
@@ -5031,89 +4966,6 @@ export default function App() {
                         />
                       ) : null}
                     </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="w-full border-t border-slate-200 bg-slate-50 p-5 text-xs text-slate-700 md:w-96 md:border-l md:border-t-0 md:text-[11px]">
-              <div className="space-y-4">
-                <div>
-                  <h3 className="text-sm font-semibold text-slate-700">Exit & growth assumptions</h3>
-                  <div className="mt-2 grid grid-cols-2 gap-2">
-                    {smallInput('exitYear', 'Exit year', 1)}
-                    {pctInput('annualAppreciation', 'Appreciation %')}
-                    {pctInput('rentGrowth', 'Rent growth %')}
-                    {pctInput('indexFundGrowth', 'Index fund growth %')}
-                    {pctInput('sellingCostsPct', 'Selling costs %')}
-                    {pctInput('discountRate', 'Discount rate %', 0.001)}
-                  </div>
-                </div>
-                <div>
-                  <h3 className="text-sm font-semibold text-slate-700">Financing levers</h3>
-                  <div className="mt-2 grid grid-cols-2 gap-2">
-                    {moneyInput('purchasePrice', 'Purchase price (£)')}
-                    {pctInput('depositPct', 'Deposit %')}
-                    {pctInput('interestRate', 'Interest rate (APR) %', 0.001)}
-                    {smallInput('mortgageYears', 'Mortgage term (years)')}
-                    {pctInput('closingCostsPct', 'Closing costs %')}
-                  </div>
-                  <div className="mt-3 rounded-xl border border-slate-200 p-3">
-                    <div className="text-xs font-semibold text-slate-700">Loan type</div>
-                    <div className="mt-2 flex flex-wrap gap-4 text-xs">
-                      <label className="inline-flex items-center gap-2">
-                        <input
-                          type="radio"
-                          name="loanTypeExpanded"
-                          checked={inputs.loanType === 'repayment'}
-                          onChange={() => setInputs((prev) => ({ ...prev, loanType: 'repayment' }))}
-                        />
-                        <span>Capital repayment</span>
-                      </label>
-                      <label className="inline-flex items-center gap-2">
-                        <input
-                          type="radio"
-                          name="loanTypeExpanded"
-                          checked={inputs.loanType === 'interest_only'}
-                          onChange={() => setInputs((prev) => ({ ...prev, loanType: 'interest_only' }))}
-                        />
-                        <span>Interest-only</span>
-                      </label>
-                    </div>
-                    <p className="mt-2 text-[11px] text-slate-500">Switching loan type updates debt service and equity projections instantly.</p>
-                  </div>
-                </div>
-                <div>
-                  <h3 className="text-sm font-semibold text-slate-700">Rental cashflow inputs</h3>
-                  <div className="mt-2 grid grid-cols-2 gap-2">
-                    {moneyInput('monthlyRent', 'Monthly rent (£)', 50)}
-                    {pctInput('vacancyPct', 'Vacancy %')}
-                    {pctInput('mgmtPct', 'Management %')}
-                    {pctInput('repairsPct', 'Repairs/CapEx %')}
-                    {moneyInput('insurancePerYear', 'Insurance (£/yr)', 50)}
-                    {moneyInput('otherOpexPerYear', 'Other OpEx (£/yr)', 50)}
-                  </div>
-                  <div className="mt-3 rounded-xl border border-slate-200 p-3">
-                    <label className="flex items-center gap-2 text-xs font-semibold text-slate-700">
-                      <input
-                        type="checkbox"
-                        checked={Boolean(inputs.reinvestIncome)}
-                        onChange={(e) =>
-                          setInputs((prev) => ({
-                            ...prev,
-                            reinvestIncome: e.target.checked,
-                          }))
-                        }
-                      />
-                      <span>Reinvest after-tax cash flow into index fund</span>
-                    </label>
-                    {inputs.reinvestIncome && (
-                      <div className="mt-2 grid grid-cols-1 gap-2">
-                        {pctInput('reinvestPct', 'Reinvest % of after-tax cash flow')}
-                        <p className="text-[11px] text-slate-500">
-                          Only positive after-tax cash flows are reinvested and compound alongside the index fund baseline.
-                        </p>
-                      </div>
-                    )}
                   </div>
                 </div>
               </div>
@@ -5955,21 +5807,6 @@ function Line({ label, value, bold = false, tooltip }) {
           {tooltip}
         </div>
       ) : null}
-    </div>
-  );
-}
-
-function SensitivityRow({ label, value }) {
-  const numericValue = Number.isFinite(value) ? value : 0;
-  const positive = numericValue >= 0;
-  return (
-    <div className="flex items-center justify-between text-xs">
-      <span className="text-slate-600">{label}</span>
-      <span
-        className={`rounded-lg px-2 py-0.5 ${positive ? 'bg-green-100 text-green-700' : 'bg-rose-100 text-rose-700'}`}
-      >
-        {currency(numericValue)}
-      </span>
     </div>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -896,10 +896,18 @@ function calculateEquity(rawInputs) {
   const totalMonths = inputs.exitYear * 12;
 
   for (let month = 1; month <= totalMonths; month++) {
+    const mortgageMonth = bridgingEnabled ? month - bridgingLoanTermMonths : month;
+    if (bridgingEnabled && mortgageMonth <= 0) {
+      continue;
+    }
+
     const yearIndex = Math.ceil(month / 12) - 1;
     if (yearIndex >= annualDebtService.length) break;
 
-    if (inputs.loanType !== 'interest_only' && (month > inputs.mortgageYears * 12 || balance <= 0)) {
+    if (
+      inputs.loanType !== 'interest_only' &&
+      (mortgageMonth > inputs.mortgageYears * 12 || balance <= 0)
+    ) {
       break;
     }
 
@@ -1121,7 +1129,8 @@ function calculateEquity(rawInputs) {
     annualCashflowsPreTax.push(cash);
     annualCashflowsAfterTax.push(afterTaxCash);
 
-    const monthsPaid = Math.min(y * 12, inputs.mortgageYears * 12);
+    const monthsPaidRaw = Math.max(0, y * 12 - (bridgingEnabled ? bridgingLoanTermMonths : 0));
+    const monthsPaid = Math.min(monthsPaidRaw, inputs.mortgageYears * 12);
     const remainingLoanYear =
       inputs.loanType === 'interest_only'
         ? loan
@@ -3940,7 +3949,7 @@ export default function App() {
                     {inputs.useBridgingLoan ? (
                       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                         {smallInput('bridgingLoanTermMonths', 'Bridging term (months)')}
-                        {pctInput('bridgingLoanInterestRate', 'Bridging rate (monthly) %', 0.001)}
+                        {pctInput('bridgingLoanInterestRate', 'Bridging rate %', 0.001)}
                       </div>
                     ) : null}
                     {inputs.useBridgingLoan ? (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -875,6 +875,7 @@ function calculateEquity(rawInputs) {
   const bridgingAmount = bridgingEnabled ? deposit : 0;
   const totalCashRequired = deposit + closing + inputs.renovationCost;
   const initialCashOutlay = Math.max(totalCashRequired - bridgingAmount, 0);
+  const indexInitialInvestment = bridgingEnabled ? deposit : initialCashOutlay;
 
   const baseIncome1 = isCompanyBuyer ? 0 : (inputs.incomePerson1 ?? 0);
   const baseIncome2 = isCompanyBuyer ? 0 : (inputs.incomePerson2 ?? 0);
@@ -978,10 +979,10 @@ function calculateEquity(rawInputs) {
   let exitCumCash = 0;
   let exitCumCashAfterTax = 0;
   let exitNetSaleProceeds = 0;
-  let indexVal = initialCashOutlay;
+  let indexVal = indexInitialInvestment;
   let reinvestFundValue = 0;
   let investedRentValue = 0;
-  const indexBasis = initialCashOutlay;
+  const indexBasis = indexInitialInvestment;
   const reinvestShare = inputs.reinvestIncome
     ? Math.min(Math.max(Number(inputs.reinvestPct ?? 0), 0), 1)
     : 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2678,6 +2678,12 @@ export default function App() {
     : 'Property net after tax';
   const verifyingAuth = authStatus === 'verifying';
   const shouldShowAuthOverlay = remoteEnabled && (authStatus === 'unauthorized' || verifyingAuth);
+  const selectedScenario = useMemo(
+    () => savedScenarios.find((item) => item.id === selectedScenarioId) ?? null,
+    [savedScenarios, selectedScenarioId]
+  );
+  const canUpdateSelectedScenario = Boolean(selectedScenario);
+  const isUpdatingScenario = syncStatus === 'updating';
   const scenarioStatus = (() => {
     if (!remoteEnabled) {
       return { message: 'Scenarios are stored locally in your browser.', tone: 'neutral', retry: false };
@@ -3940,14 +3946,28 @@ export default function App() {
               <div className="rounded-2xl bg-white p-3 shadow-sm">
                 <div className="mb-2 flex items-center justify-between gap-2">
                   <h2 className="text-base font-semibold">Deal Inputs</h2>
-                  <button
-                    type="button"
-                    onClick={handleResetInputs}
-                    className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-slate-300 text-xs font-semibold text-slate-600 transition hover:bg-slate-100"
-                    aria-label="Reset deal inputs"
-                  >
-                    <span aria-hidden="true">↻</span>
-                  </button>
+                  <div className="flex items-center gap-1">
+                    {canUpdateSelectedScenario ? (
+                      <button
+                        type="button"
+                        onClick={() => handleUpdateScenario(selectedScenario.id)}
+                        className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-slate-300 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        aria-label="Update saved scenario"
+                        title="Update saved scenario"
+                        disabled={isUpdatingScenario}
+                      >
+                        <span aria-hidden="true">💾</span>
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={handleResetInputs}
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-slate-300 text-xs font-semibold text-slate-600 transition hover:bg-slate-100"
+                      aria-label="Reset deal inputs"
+                    >
+                      <span aria-hidden="true">↻</span>
+                    </button>
+                  </div>
                 </div>
 
                 <CollapsibleSection

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -314,6 +314,7 @@ const normalizeScenarioList = (list) =>
 const DEFAULT_INPUTS = {
   propertyAddress: '',
   propertyUrl: '',
+  bedrooms: 3,
   purchasePrice: 70000,
   depositPct: 0.25,
   closingCostsPct: 0.01,
@@ -2463,10 +2464,17 @@ export default function App() {
         const metrics = calculateEquity(evaluationInputs);
         const grossRentYear1 = Number(metrics.grossRentYear1) || 0;
         const purchasePrice = Number(evaluationInputs.purchasePrice ?? basePurchasePrice) || 0;
+        const monthlyRent = Number(evaluationInputs.monthlyRent ?? baseMonthlyRent) || 0;
+        const bedroomsValue = Number(
+          evaluationInputs.bedrooms ?? scenarioDefaults.bedrooms ?? DEFAULT_INPUTS.bedrooms
+        );
         const rentalYieldValue = purchasePrice > 0 ? grossRentYear1 / purchasePrice : 0;
         return {
           scenario,
           metrics,
+          purchasePrice,
+          monthlyRent,
+          bedrooms: Number.isFinite(bedroomsValue) ? bedroomsValue : null,
           ratios: {
             cap: Number.isFinite(metrics.cap) ? metrics.cap : 0,
             rentalYield: Number.isFinite(rentalYieldValue) ? rentalYieldValue : 0,
@@ -2535,7 +2543,7 @@ export default function App() {
       return [];
     }
     return scenarioTableData
-      .map(({ scenario, metrics, ratios }) => {
+      .map(({ scenario, metrics, ratios, purchasePrice, monthlyRent, bedrooms }) => {
         const x = ratios?.[scenarioScatterXAxis];
         const y = ratios?.[scenarioScatterYAxis];
         const propertyNetAfterTax = Number(metrics.propertyNetWealthAfterTax) || 0;
@@ -2545,6 +2553,9 @@ export default function App() {
           x: Number.isFinite(x) ? x : null,
           y: Number.isFinite(y) ? y : null,
           propertyNetAfterTax,
+          purchasePrice: Number.isFinite(purchasePrice) ? purchasePrice : null,
+          monthlyRent: Number.isFinite(monthlyRent) ? monthlyRent : null,
+          bedrooms: Number.isFinite(bedrooms) ? bedrooms : null,
           savedAt: scenario.savedAt,
           isActive: scenario.id === selectedScenarioId,
         };
@@ -4835,6 +4846,7 @@ export default function App() {
                 >
                   <div className="grid gap-2 md:grid-cols-2">
                   <div className="md:col-span-2">{textInput('propertyAddress', 'Property address')}</div>
+                  <div>{smallInput('bedrooms', 'Bedrooms', 1, 0)}</div>
                   <div className="flex flex-col gap-1 md:col-span-2">
                     <label className="text-xs font-medium text-slate-600">Property URL</label>
                     <div className="flex items-center gap-2">
@@ -6324,6 +6336,8 @@ export default function App() {
                     <div className="divide-y divide-slate-200 rounded-xl border border-slate-200">
                       {savedScenarios.map((scenario) => {
                         const isSelected = selectedScenarioId === scenario.id;
+                        const bedroomCount = Number(scenario.data?.bedrooms);
+                        const hasBedroomCount = Number.isFinite(bedroomCount) && bedroomCount > 0;
                         return (
                           <div
                             key={`${scenario.id}-meta`}
@@ -6343,6 +6357,12 @@ export default function App() {
                               <span>Saved: {friendlyDateTime(scenario.savedAt)}</span>
                               {scenario.data?.propertyAddress ? (
                                 <span className="text-slate-500">{scenario.data.propertyAddress}</span>
+                              ) : null}
+                              {hasBedroomCount ? (
+                                <span className="text-slate-500">
+                                  {bedroomCount}{' '}
+                                  {bedroomCount === 1 ? 'bedroom' : 'bedrooms'}
+                                </span>
                               ) : null}
                               {scenario.data?.propertyUrl ? (
                                 <a
@@ -7273,6 +7293,12 @@ export default function App() {
                                     <div className="font-semibold text-slate-800">{datum.name}</div>
                                     <div>{scenarioScatterXAxisOption?.label}: {formatPercent(datum.x)}</div>
                                     <div>{scenarioScatterYAxisOption?.label}: {formatPercent(datum.y)}</div>
+                                    {Number.isFinite(datum.purchasePrice) ? (
+                                      <div>Purchase price: {currency(datum.purchasePrice)}</div>
+                                    ) : null}
+                                    {Number.isFinite(datum.monthlyRent) ? (
+                                      <div>Monthly rent: {currency(datum.monthlyRent)}</div>
+                                    ) : null}
                                     <div>
                                       {propertyNetAfterTaxLabel}: {currency(datum.propertyNetAfterTax)}
                                     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1268,6 +1268,7 @@ export default function App() {
   const [previewStatus, setPreviewStatus] = useState('idle');
   const [previewError, setPreviewError] = useState('');
   const [previewKey, setPreviewKey] = useState(0);
+  const [isMapModalOpen, setIsMapModalOpen] = useState(false);
   const remoteEnabled = Boolean(SCENARIO_API_URL);
   const [authCredentials, setAuthCredentials] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -1905,13 +1906,26 @@ export default function App() {
     }
     const latFixed = lat.toFixed(6);
     const lonFixed = lon.toFixed(6);
+    const padding = 0.01;
+    const south = (lat - padding).toFixed(6);
+    const west = (lon - padding).toFixed(6);
+    const north = (lat + padding).toFixed(6);
+    const east = (lon + padding).toFixed(6);
+    const bbox = `${west},${south},${east},${north}`;
     return {
       lat,
       lon,
       displayName: geocodeState.data.displayName,
-      imageUrl: `https://staticmap.openstreetmap.org/staticmap.php?center=${latFixed},${lonFixed}&zoom=15&size=400x220&markers=${latFixed},${lonFixed},red-pushpin`,
+      embedUrl: `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${latFixed}%2C${lonFixed}`,
+      viewUrl: `https://www.openstreetmap.org/?mlat=${latFixed}&mlon=${lonFixed}#map=15/${latFixed}/${lonFixed}`,
     };
   }, [geocodeState.data]);
+
+  useEffect(() => {
+    if (!locationPreview) {
+      setIsMapModalOpen(false);
+    }
+  }, [locationPreview]);
 
 
   const exitYears = Math.max(0, Math.round(Number(inputs.exitYear) || 0));
@@ -3569,16 +3583,30 @@ export default function App() {
                   </p>
                 ) : null}
                 {locationPreview ? (
-                  <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-2">
-                    <div className="text-[11px] font-semibold text-slate-600">Map preview</div>
+                  <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                    <div className="text-[11px] font-semibold text-slate-600">Property location</div>
                     <p className="mt-1 text-[11px] text-slate-500">{locationPreview.displayName}</p>
-                    <img
-                      src={locationPreview.imageUrl}
-                      alt={`Map preview for ${locationPreview.displayName}`}
-                      className="mt-2 h-40 w-full rounded-xl object-cover"
-                      loading="lazy"
-                    />
-                    <div className="mt-1 text-[10px] uppercase tracking-wide text-slate-400">
+                    <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px]">
+                      <button
+                        type="button"
+                        onClick={() => setIsMapModalOpen(true)}
+                        className="inline-flex items-center gap-2 rounded-full border border-indigo-200 px-3 py-1 text-xs font-semibold text-indigo-700 transition hover:bg-indigo-50"
+                      >
+                        <span role="img" aria-hidden="true">
+                          🗺️
+                        </span>
+                        Open interactive map
+                      </button>
+                      <a
+                        href={locationPreview.viewUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100"
+                      >
+                        View on OpenStreetMap
+                      </a>
+                    </div>
+                    <div className="mt-2 text-[10px] uppercase tracking-wide text-slate-400">
                       Map data © OpenStreetMap contributors
                     </div>
                   </div>
@@ -5547,6 +5575,47 @@ export default function App() {
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+      </div>
+    )}
+
+    {isMapModalOpen && locationPreview && (
+      <div className="no-print fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70 backdrop-blur-sm">
+        <div className="relative w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-2xl">
+          <div className="flex items-center justify-between border-b border-slate-200 px-5 py-3">
+            <div>
+              <h2 className="text-base font-semibold text-slate-800">Property location</h2>
+              <p className="text-[11px] text-slate-500">{locationPreview.displayName}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsMapModalOpen(false)}
+              className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100"
+            >
+              Close
+            </button>
+          </div>
+          <div className="aspect-video w-full">
+            <iframe
+              title={`OpenStreetMap location for ${locationPreview.displayName}`}
+              src={locationPreview.embedUrl}
+              className="h-full w-full"
+              style={{ border: 0 }}
+              loading="lazy"
+              referrerPolicy="no-referrer-when-downgrade"
+            />
+          </div>
+          <div className="flex items-center justify-between border-t border-slate-200 px-5 py-3 text-[11px] text-slate-500">
+            <span>Map data © OpenStreetMap contributors</span>
+            <a
+              href={locationPreview.viewUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100"
+            >
+              Open full map
+            </a>
           </div>
         </div>
       </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1775,6 +1775,31 @@ export default function App() {
     });
   }, [equity.chart]);
 
+
+  const exitYears = Math.max(0, Math.round(Number(inputs.exitYear) || 0));
+  const appreciationRate = Number(inputs.annualAppreciation) || 0;
+  const sellingCostsRate = Number(inputs.sellingCostsPct) || 0;
+  const appreciationFactor = 1 + appreciationRate;
+  const appreciationFactorDisplay = appreciationFactor.toFixed(4);
+  const appreciationPower = Math.pow(appreciationFactor, exitYears);
+  const appreciationPowerDisplay = appreciationPower.toFixed(4);
+  const predictedRentYield = useMemo(() => {
+    const price = Number(inputs.purchasePrice) || 0;
+    const rent = Number(inputs.monthlyRent) || 0;
+    if (!Number.isFinite(price) || price <= 0) {
+      return 0;
+    }
+    return (rent * 12) / price;
+  }, [inputs.purchasePrice, inputs.monthlyRent]);
+  const roiHeatmapYieldOptions = useMemo(
+    () => ROI_HEATMAP_OFFSETS.map((offset) => Math.max(predictedRentYield + offset, 0)),
+    [predictedRentYield]
+  );
+  const roiHeatmapGrowthOptions = useMemo(
+    () => ROI_HEATMAP_OFFSETS.map((offset) => appreciationRate + offset),
+    [appreciationRate]
+  );
+
   const roiHeatmapData = useMemo(() => {
     const purchasePrice = Number(inputs.purchasePrice) || 0;
     if (!Number.isFinite(purchasePrice) || purchasePrice <= 0) {
@@ -2046,29 +2071,6 @@ export default function App() {
   const propertyNetAfterTaxLabel = isCompanyBuyer
     ? 'Property net after corporation tax'
     : 'Property net after tax';
-  const exitYears = Math.max(0, Math.round(Number(inputs.exitYear) || 0));
-  const appreciationRate = Number(inputs.annualAppreciation) || 0;
-  const sellingCostsRate = Number(inputs.sellingCostsPct) || 0;
-  const appreciationFactor = 1 + appreciationRate;
-  const appreciationFactorDisplay = appreciationFactor.toFixed(4);
-  const appreciationPower = Math.pow(appreciationFactor, exitYears);
-  const appreciationPowerDisplay = appreciationPower.toFixed(4);
-  const predictedRentYield = useMemo(() => {
-    const price = Number(inputs.purchasePrice) || 0;
-    const rent = Number(inputs.monthlyRent) || 0;
-    if (!Number.isFinite(price) || price <= 0) {
-      return 0;
-    }
-    return (rent * 12) / price;
-  }, [inputs.purchasePrice, inputs.monthlyRent]);
-  const roiHeatmapYieldOptions = useMemo(
-    () => ROI_HEATMAP_OFFSETS.map((offset) => Math.max(predictedRentYield + offset, 0)),
-    [predictedRentYield]
-  );
-  const roiHeatmapGrowthOptions = useMemo(
-    () => ROI_HEATMAP_OFFSETS.map((offset) => appreciationRate + offset),
-    [appreciationRate]
-  );
   const verifyingAuth = authStatus === 'verifying';
   const shouldShowAuthOverlay = remoteEnabled && (authStatus === 'unauthorized' || verifyingAuth);
   const scenarioStatus = (() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,19 @@ import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
 
 const currency = (n) => (isFinite(n) ? n.toLocaleString(undefined, { style: 'currency', currency: 'GBP' }) : '–');
+const currencyThousands = (value) => {
+  if (!isFinite(value)) {
+    return '–';
+  }
+  const negative = value < 0;
+  const absoluteThousands = Math.abs(value) / 1000;
+  const maximumFractionDigits = absoluteThousands >= 100 ? 0 : absoluteThousands >= 10 ? 1 : 2;
+  const formatted = absoluteThousands.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits,
+  });
+  return `${negative ? '−' : ''}£${formatted}k`;
+};
 const DEFAULT_INDEX_GROWTH = 0.07;
 const SCENARIO_STORAGE_KEY = 'qc_saved_scenarios';
 const SCENARIO_AUTH_STORAGE_KEY = 'qc_saved_scenario_auth';
@@ -3601,9 +3614,39 @@ export default function App() {
                         href={locationPreview.viewUrl}
                         target="_blank"
                         rel="noreferrer"
-                        className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100"
+                        aria-label="Open location on OpenStreetMap"
+                        className="inline-flex items-center justify-center rounded-full border border-slate-300 px-2.5 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-100"
                       >
-                        View on OpenStreetMap
+                        <span className="sr-only">View on OpenStreetMap</span>
+                        <svg
+                          aria-hidden="true"
+                          className="h-4 w-4"
+                          viewBox="0 0 20 20"
+                          fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11.25 3.5H5.5A2 2 0 0 0 3.5 5.5v9A2 2 0 0 0 5.5 16.5h9a2 2 0 0 0 2-2v-5.75"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <path
+                            d="M9.5 10.5 16.5 3.5"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <path
+                            d="M12.5 3.5h4v4"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
                       </a>
                     </div>
                     <div className="mt-2 text-[10px] uppercase tracking-wide text-slate-400">
@@ -4432,7 +4475,7 @@ export default function App() {
                       {hasLeverageData ? (
                         <>
                           <ResponsiveContainer>
-                            <LineChart data={leverageChartData} margin={{ top: 10, right: 80, left: 0, bottom: 0 }}>
+                            <LineChart data={leverageChartData} margin={{ top: 10, right: 48, left: 0, bottom: 0 }}>
                               <CartesianGrid strokeDasharray="3 3" />
                               <XAxis
                                 dataKey="ltv"
@@ -4451,9 +4494,9 @@ export default function App() {
                               <YAxis
                                 yAxisId="right"
                                 orientation="right"
-                                tickFormatter={(value) => currency(value)}
+                                tickFormatter={(value) => currencyThousands(value)}
                                 tick={{ fontSize: 11, fill: '#475569' }}
-                                width={120}
+                                width={88}
                               />
                               <Tooltip
                                 formatter={(value, name, { dataKey }) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import {
   Line as RechartsLine,
   ScatterChart,
   Scatter,
+  Cell,
 } from 'recharts';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
@@ -2103,10 +2104,11 @@ export default function App() {
           y: Number.isFinite(y) ? y : null,
           propertyNetAfterTax,
           savedAt: scenario.savedAt,
+          isActive: scenario.id === selectedScenarioId,
         };
       })
       .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y));
-  }, [scenarioScatterXAxis, scenarioScatterYAxis, scenarioTableData]);
+  }, [scenarioScatterXAxis, scenarioScatterYAxis, scenarioTableData, selectedScenarioId]);
   const scenarioScatterXAxisOption = useMemo(
     () =>
       SCENARIO_RATIO_PERCENT_COLUMNS.find((option) => option.key === scenarioScatterXAxis) ??
@@ -6312,7 +6314,14 @@ export default function App() {
                                   });
                                 }
                               }}
-                            />
+                            >
+                              {scenarioScatterData.map((point) => (
+                                <Cell
+                                  key={`scatter-${point.id}`}
+                                  fill={point.isActive ? '#16a34a' : '#2563eb'}
+                                />
+                              ))}
+                            </Scatter>
                           </ScatterChart>
                         </ResponsiveContainer>
                       )}
@@ -6378,7 +6387,23 @@ export default function App() {
                       <tbody className="divide-y divide-slate-200">
                         {scenarioTableSorted.map(({ scenario, metrics, ratios }) => (
                           <tr key={`table-${scenario.id}`} className="odd:bg-white even:bg-slate-50">
-                            <td className="px-4 py-2 font-semibold text-slate-800">{scenario.name}</td>
+                            <td className="px-4 py-2 font-semibold">
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  handleLoadScenario(scenario.id, {
+                                    closeTableOnLoad: true,
+                                  })
+                                }
+                                className={`text-left transition hover:text-indigo-700 hover:underline ${
+                                  selectedScenarioId === scenario.id
+                                    ? 'text-indigo-700 underline'
+                                    : 'text-slate-800'
+                                }`}
+                              >
+                                {scenario.name}
+                              </button>
+                            </td>
                             <td className="px-4 py-2 text-slate-600">{friendlyDateTime(scenario.savedAt)}</td>
                             <td className="px-4 py-2 text-right text-slate-700">
                               {currency(metrics.propertyNetWealthAfterTax)}


### PR DESCRIPTION
## Summary
- add a stored collapse state for the wealth trajectory chart card
- add UI controls to hide or show the chart content and keep the modal expand button available when expanded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14eec0314832fad4b2e8da86eb05d