### PR TITLE
Add property type options and expand deal scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A Vite + React single-page application for reviewing the financial performance of a UK buy-to-let property investment. The app models cash needs, year-one operations, leverage metrics, and a comparison to investing in an index fund.
 
+## Market data insights
+
+- **Property type intelligence** – Choose between detached, semi-detached, terraced, and flat/maisonette stock to tailor cash-flow and appreciation assumptions. Historical price data from `Average-prices-Property-Type-2025-07.csv` is parsed at runtime so the projection reflects the selected asset class.
+- **Historical appreciation overlays** – Swap the manual growth assumption for 1, 5, 10, or 20 year UK averages derived from the CSV data. When enabled, the projection automatically applies the relevant long-run appreciation rate for the property type in question.
+- **Comprehensive scoring** – The investment score now blends market growth resilience, local crime safety (benchmarked against UK averages), DSCR, LTV, total ROI, and traditional return metrics to produce a richer composite rating.
+
 ## Getting started
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 A Vite + React single-page application for reviewing the financial performance of a UK buy-to-let property investment. The app models cash needs, year-one operations, leverage metrics, and a comparison to investing in an index fund.
 
-## Market data insights
-
-- **Property type intelligence** – Choose between detached, semi-detached, terraced, and flat/maisonette stock to tailor cash-flow and appreciation assumptions. Historical price data from `Average-prices-Property-Type-2025-07.csv` is parsed at runtime so the projection reflects the selected asset class.
-- **Historical appreciation overlays** – Swap the manual growth assumption for 1, 5, 10, or 20 year UK averages derived from the CSV data. When enabled, the projection automatically applies the relevant long-run appreciation rate for the property type in question.
-- **Comprehensive scoring** – The investment score now blends market growth resilience, local crime safety (benchmarked against UK averages), DSCR, LTV, total ROI, and traditional return metrics to produce a richer composite rating.
-
 ## Getting started
 
 ```bash
@@ -24,6 +18,12 @@ npm run build
 ```
 
 > **Note:** The default styling relies on Tailwind CSS, which is compiled during the build step.
+
+## UK market data & scoring
+
+- Choose a property type in the **Property info** panel to align the analysis with Land Registry averages for detached, semi-detached, terraced, or flats/maisonettes. The selector surfaces the latest national pricing snapshot and long-run CAGR pulled from `Average-prices-Property-Type-2025-07.csv`.
+- Under **Rental cashflow** you can keep a manual capital growth assumption or toggle to apply the historical CAGR for the selected property type across 1, 5, 10, or 20-year windows. When enabled, projections ignore the manual field and compound using the chosen data window.
+- The composite investment score now blends cap rate strength, DSCR resilience, 20-year market growth, and crime safety (benchmarked against UK averages) alongside the existing return metrics so the grade reflects both performance and location risk.
 
 ## Scenario persistence
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3186,7 +3186,8 @@ function calculateEquity(rawInputs) {
     propertyGrowthWindowYears: Number.isFinite(inputs.propertyGrowthWindowYears)
       ? inputs.propertyGrowthWindowYears
       : null,
-    propertyGrowthSource: propertyGrowthRegionSummary,
+    propertyGrowthSource:
+      typeof inputs.propertyGrowthSource === 'string' ? inputs.propertyGrowthSource : '',
     propertyTypeLabel: typeof inputs.propertyTypeLabel === 'string' ? inputs.propertyTypeLabel : '',
     localCrimeRatePerThousand: Number.isFinite(inputs.localCrimeRatePerThousand)
       ? inputs.localCrimeRatePerThousand
@@ -4558,6 +4559,7 @@ export default function App() {
       propertyGrowthWindowRate: derivedRate,
       propertyGrowth20Year: longRunRate,
       propertyTypeLabel,
+      propertyGrowthSource: propertyGrowthRegionSummary,
       localCrimeRatePerThousand: crimeRateValue,
       ukCrimeRatePerThousand: UK_ANNUAL_CRIME_PER_1000,
     };
@@ -4569,6 +4571,7 @@ export default function App() {
     derivedHistoricalRate,
     longTermGrowthRate,
     propertyTypeLabel,
+    propertyGrowthRegionSummary,
     localCrimeAnnualRatePerThousand,
   ]);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -166,6 +166,10 @@ const COUNTRY_REGION_SYNONYMS = {
   'great britain': 'united kingdom',
   britain: 'united kingdom',
   'united kingdom of great britain and northern ireland': 'united kingdom',
+  'gb-eng': 'england',
+  'gb-wls': 'wales',
+  'gb-sct': 'scotland',
+  'gb-nir': 'northern ireland',
 };
 
 const PROPERTY_APPRECIATION_WINDOWS = [1, 5, 10, 20];
@@ -3515,6 +3519,8 @@ export default function App() {
   const geocodeAddressQuery = geocodeAddressDetails.query;
   const geocodeBounds = geocodeAddressDetails.bounds;
   const geocodePostcode = geocodeAddressDetails.postcode;
+  const geocodeCountyName = geocodeAddressDetails.county;
+  const geocodeCityName = geocodeAddressDetails.city;
   const geocodeStateName = geocodeAddressDetails.state;
   const geocodeCountry = geocodeAddressDetails.country;
   const geocodeCountryCode = geocodeAddressDetails.countryCode;
@@ -3539,8 +3545,11 @@ export default function App() {
       seen.add(canonical);
       candidateKeys.push(canonical);
     };
-    if (geocodeCountry) {
-      pushCandidate(geocodeCountry);
+    if (geocodeCountyName) {
+      pushCandidate(geocodeCountyName);
+    }
+    if (geocodeCityName) {
+      pushCandidate(geocodeCityName);
     }
     if (geocodeStateName) {
       pushCandidate(geocodeStateName);
@@ -3551,6 +3560,9 @@ export default function App() {
       if (mapped) {
         pushCandidate(mapped);
       }
+    }
+    if (geocodeCountry) {
+      pushCandidate(geocodeCountry);
     }
     for (const canonicalKey of candidateKeys) {
       const regionEntry = regions[canonicalKey];
@@ -3567,7 +3579,14 @@ export default function App() {
       label: globalEntry?.label ?? '',
       fallback: true,
     };
-  }, [propertyPriceState, geocodeCountry, geocodeCountryCode, geocodeStateName]);
+  }, [
+    propertyPriceState,
+    geocodeCityName,
+    geocodeCountyName,
+    geocodeCountry,
+    geocodeCountryCode,
+    geocodeStateName,
+  ]);
 
   const propertyPriceStats = propertyPriceStatsSelection.stats;
   const propertyGrowthRegionLabel = propertyPriceStatsSelection.label;


### PR DESCRIPTION
## Summary
- parse the national property price CSV and expose a property type selector with historical appreciation overrides
- feed historical growth and local crime metrics into projections and summary displays
- expand the composite score with market growth, safety, leverage, and ROI factors for richer deal grading

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e784d2c16c832fa2eac211067929ea