### PR TITLE
Add spreadsheet export for cash flow table

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "mysql2": "^3.9.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "recharts": "^2.9.0"
+    "recharts": "^2.9.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.19",


### PR DESCRIPTION
## Summary
- add an XLSX-based spreadsheet export for the cash flow table
- update the cash flow table action to reflect the spreadsheet download
- declare the `xlsx` dependency required for spreadsheet generation

## Testing
- npm install *(fails: 403 Forbidden when reaching the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eff3967960832f9109a8ef653b2ffc