### PR TITLE
Add market value section to investment report

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -759,6 +759,102 @@ const getAddressComponent = (address, keys) => {
   return '';
 };
 
+const normalizeBoundingBox = (value) => {
+  if (!value) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parts = value.split(',').map((part) => part.trim());
+    if (parts.length === 4) {
+      return parts;
+    }
+  }
+  if (typeof value === 'object') {
+    const south =
+      value.south ?? value.s ?? value.min_lat ?? value.minLat ?? value.minLatitude ?? null;
+    const north =
+      value.north ?? value.n ?? value.max_lat ?? value.maxLat ?? value.maxLatitude ?? null;
+    const west = value.west ?? value.w ?? value.min_lon ?? value.minLon ?? value.minLongitude ?? null;
+    const east = value.east ?? value.e ?? value.max_lon ?? value.maxLon ?? value.maxLongitude ?? null;
+    if (south != null && north != null && west != null && east != null) {
+      return [south, north, west, east].map((part) => `${part}`);
+    }
+  }
+  return null;
+};
+
+const normalizeGeocodeCandidate = (candidate, fallbackLabel) => {
+  if (!candidate || typeof candidate !== 'object') {
+    return null;
+  }
+  const lat = Number.parseFloat(candidate.lat ?? candidate.latitude);
+  const lon = Number.parseFloat(candidate.lon ?? candidate.longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return null;
+  }
+  const displayNameRaw =
+    typeof candidate.display_name === 'string' && candidate.display_name.trim() !== ''
+      ? candidate.display_name
+      : typeof candidate.displayName === 'string' && candidate.displayName.trim() !== ''
+      ? candidate.displayName
+      : '';
+  const displayName = displayNameRaw.trim() !== '' ? displayNameRaw.trim() : fallbackLabel;
+  const addressDetails =
+    candidate.address && typeof candidate.address === 'object' && candidate.address !== null
+      ? candidate.address
+      : null;
+  const boundingBox = normalizeBoundingBox(
+    candidate.boundingbox ?? candidate.boundingBox ?? candidate.bbox ?? null
+  );
+  return {
+    lat,
+    lon,
+    displayName,
+    address: addressDetails,
+    boundingBox,
+  };
+};
+
+const GEOCODE_PROVIDERS = [
+  {
+    buildUrl: (query) => {
+      const params = new URLSearchParams({ q: query, limit: '1' });
+      return `https://geocode.maps.co/search?${params.toString()}`;
+    },
+    parse: (payload) => (Array.isArray(payload) ? payload : []),
+    headers: { Accept: 'application/json' },
+  },
+  {
+    buildUrl: (query) => {
+      const params = new URLSearchParams({
+        q: query,
+        format: 'jsonv2',
+        addressdetails: '1',
+        limit: '1',
+      });
+      return `https://nominatim.openstreetmap.org/search?${params.toString()}`;
+    },
+    parse: (payload) => {
+      if (Array.isArray(payload)) {
+        return payload;
+      }
+      if (payload && typeof payload === 'object') {
+        if (Array.isArray(payload.results)) {
+          return payload.results;
+        }
+        if (Array.isArray(payload.places)) {
+          return payload.places;
+        }
+      }
+      return [];
+    },
+    headers: { Accept: 'application/json', 'Accept-Language': 'en' },
+  },
+];
+
 const parseBoundingBox = (boundingBox) => {
   if (!Array.isArray(boundingBox) || boundingBox.length !== 4) {
     return null;
@@ -8932,47 +9028,53 @@ export default function App() {
       const controller = new AbortController();
       geocodeAbortRef.current = controller;
       setGeocodeState((prev) => ({ status: 'loading', data: prev.data ?? null, error: '' }));
-      const params = new URLSearchParams({ q: rawAddress, limit: '1' });
-      fetch(`https://geocode.maps.co/search?${params.toString()}`, {
-        signal: controller.signal,
-        headers: { Accept: 'application/json' },
-      })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error('Geocoding request failed');
+
+      const fetchGeocodeCandidate = async () => {
+        let lastError = null;
+        for (const provider of GEOCODE_PROVIDERS) {
+          const headers = { Accept: 'application/json', ...(provider.headers ?? {}) };
+          try {
+            const response = await fetch(provider.buildUrl(rawAddress), {
+              signal: controller.signal,
+              headers,
+            });
+            if (!response.ok) {
+              const error = new Error('Geocoding request failed');
+              error.status = response.status;
+              throw error;
+            }
+            const payload = await response.json();
+            const candidates = provider.parse(payload);
+            if (Array.isArray(candidates) && candidates.length > 0) {
+              const normalized = normalizeGeocodeCandidate(candidates[0], rawAddress);
+              if (normalized) {
+                return normalized;
+              }
+            }
+          } catch (error) {
+            if (error.name === 'AbortError') {
+              throw error;
+            }
+            lastError = error;
           }
-          return response.json();
-        })
-        .then((results) => {
-          if (!Array.isArray(results) || results.length === 0) {
+        }
+        if (lastError) {
+          throw lastError;
+        }
+        return null;
+      };
+
+      fetchGeocodeCandidate()
+        .then((result) => {
+          if (!result) {
             setGeocodeState({ status: 'error', data: null, error: 'No matching location found.' });
             lastGeocodeQueryRef.current = '';
             return;
           }
-          const result = results[0];
-          const lat = Number.parseFloat(result.lat);
-          const lon = Number.parseFloat(result.lon);
-          if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
-            setGeocodeState({ status: 'error', data: null, error: 'Location lookup returned invalid coordinates.' });
-            lastGeocodeQueryRef.current = '';
-            return;
-          }
           lastGeocodeQueryRef.current = normalizedQuery;
-          const addressDetails =
-            result && typeof result.address === 'object' && result.address !== null ? result.address : null;
-          const boundingBox = Array.isArray(result?.boundingbox) ? result.boundingbox : null;
-
           setGeocodeState({
             status: 'success',
-            data: {
-              lat,
-              lon,
-              displayName: typeof result.display_name === 'string' && result.display_name.trim() !== ''
-                ? result.display_name
-                : rawAddress,
-              address: addressDetails,
-              boundingBox,
-            },
+            data: result,
             error: '',
           });
         })

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -627,6 +627,7 @@ const PROPERTY_APPRECIATION_WINDOWS = [1, 5, 10, 20];
 const DEFAULT_APPRECIATION_WINDOW = 5;
 const CRIME_SEARCH_RADIUS_KM = 1.60934;
 const CRIME_SEARCH_AREA_KM2 = Math.PI * CRIME_SEARCH_RADIUS_KM * CRIME_SEARCH_RADIUS_KM;
+const CRIME_DATA_PUBLICATION_LAG_MONTHS = 2;
 const CRIME_DENSITY_CLASSIFICATIONS = [
   { max: 0.25, label: 'minimal', multiplier: 1, tone: 'positive' },
   { max: 0.75, label: 'very low', multiplier: 0.9, tone: 'positive' },
@@ -821,14 +822,6 @@ const normalizeGeocodeCandidate = (candidate, fallbackLabel) => {
 const GEOCODE_PROVIDERS = [
   {
     buildUrl: (query) => {
-      const params = new URLSearchParams({ q: query, limit: '1' });
-      return `https://geocode.maps.co/search?${params.toString()}`;
-    },
-    parse: (payload) => (Array.isArray(payload) ? payload : []),
-    headers: { Accept: 'application/json' },
-  },
-  {
-    buildUrl: (query) => {
       const params = new URLSearchParams({
         q: query,
         format: 'jsonv2',
@@ -852,6 +845,15 @@ const GEOCODE_PROVIDERS = [
       return [];
     },
     headers: { Accept: 'application/json', 'Accept-Language': 'en' },
+  },
+  {
+    shouldUse: () => typeof window === 'undefined',
+    buildUrl: (query) => {
+      const params = new URLSearchParams({ q: query, limit: '1' });
+      return `https://geocode.maps.co/search?${params.toString()}`;
+    },
+    parse: (payload) => (Array.isArray(payload) ? payload : []),
+    headers: { Accept: 'application/json' },
   },
 ];
 
@@ -977,6 +979,58 @@ const normalizeCrimeMonth = (value) => {
     return '';
   }
   return `${monthMatch[1]}-${monthMatch[2]}`;
+};
+
+const formatCrimeMonthIso = (date) => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+};
+
+const parseCrimeMonthToDate = (value) => {
+  const normalized = normalizeCrimeMonth(value);
+  if (!normalized) {
+    return null;
+  }
+  const [yearString, monthString] = normalized.split('-');
+  const year = Number(yearString);
+  const monthIndex = Number(monthString) - 1;
+  if (!Number.isFinite(year) || !Number.isFinite(monthIndex)) {
+    return null;
+  }
+  const date = new Date(Date.UTC(year, monthIndex, 1));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+};
+
+const computeCrimeLaggedMonth = (lagMonths = CRIME_DATA_PUBLICATION_LAG_MONTHS) => {
+  const lag = Number.isFinite(lagMonths) ? Math.max(0, Math.floor(lagMonths)) : 0;
+  const now = new Date();
+  const base = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  base.setUTCMonth(base.getUTCMonth() - lag);
+  return formatCrimeMonthIso(base);
+};
+
+const clampCrimeMonthToLag = (candidateMonth, lagMonths = CRIME_DATA_PUBLICATION_LAG_MONTHS) => {
+  const fallback = computeCrimeLaggedMonth(lagMonths);
+  const fallbackDate = parseCrimeMonthToDate(fallback);
+  const candidateDate = parseCrimeMonthToDate(candidateMonth);
+  if (!fallbackDate && !candidateDate) {
+    return '';
+  }
+  if (!candidateDate) {
+    return fallback;
+  }
+  if (!fallbackDate) {
+    return formatCrimeMonthIso(candidateDate);
+  }
+  if (candidateDate.getTime() > fallbackDate.getTime()) {
+    return formatCrimeMonthIso(fallbackDate);
+  }
+  return formatCrimeMonthIso(candidateDate);
 };
 
 const distanceSquared = (lat1, lon1, lat2, lon2) => {
@@ -9032,6 +9086,9 @@ export default function App() {
       const fetchGeocodeCandidate = async () => {
         let lastError = null;
         for (const provider of GEOCODE_PROVIDERS) {
+          if (provider.shouldUse && !provider.shouldUse()) {
+            continue;
+          }
           const headers = { Accept: 'application/json', ...(provider.headers ?? {}) };
           try {
             const response = await fetch(provider.buildUrl(rawAddress), {
@@ -9308,7 +9365,9 @@ export default function App() {
           console.warn('Unable to fetch crime last-updated metadata:', error);
         }
 
-        const createCrimeParams = (entries) => {
+        const resolvedLatestMonth = clampCrimeMonthToLag(lastUpdatedMonth || lastUpdatedDate || '');
+
+        const createCrimeParams = (entries, options = {}) => {
           const params = new URLSearchParams();
           if (entries && typeof entries === 'object') {
             Object.entries(entries).forEach(([key, value]) => {
@@ -9331,7 +9390,8 @@ export default function App() {
               }
             });
           }
-          const dateParam = normalizeCrimeMonth(lastUpdatedMonth || lastUpdatedDate);
+          const dateOverride = normalizeCrimeMonth(options.date);
+          const dateParam = dateOverride || resolvedLatestMonth;
           if (dateParam) {
             params.set('date', dateParam);
           }
@@ -9344,10 +9404,12 @@ export default function App() {
         const baseParams =
           crimePostcodeQuery !== ''
             ? createCrimeParams({ postcode: crimePostcodeQuery })
-            : createCrimeParams({
-                lat: latParam,
-                lng: lonParam,
-              });
+            : createCrimeParams(
+                {
+                  lat: latParam,
+                  lng: lonParam,
+                }
+              );
 
         const fetchCrimesWithParams = async (searchParams) => {
           const url = `https://data.police.uk/api/crimes-street/all-crime?${searchParams.toString()}`;
@@ -9415,7 +9477,7 @@ export default function App() {
               throw error;
             }
             finalError = error;
-            if (typeof error?.status === 'number' && error.status !== 404) {
+            if (typeof error?.status === 'number' && error.status !== 404 && error.status !== 400) {
               throw error;
             }
             return null;
@@ -9484,9 +9546,13 @@ export default function App() {
           throw new Error(fallbackErrorMessage);
         }
 
-        const defaultMonth = normalizeCrimeMonth(
-          lastUpdatedMonth || (typeof finalCrimeData[0]?.month === 'string' ? finalCrimeData[0].month : '')
-        );
+        const resolvedDefaultMonth =
+          normalizeCrimeMonth(
+            lastSuccessfulParams?.get('date') ||
+              (typeof finalCrimeData[0]?.month === 'string' ? finalCrimeData[0].month : '') ||
+              resolvedLatestMonth
+          ) || resolvedLatestMonth;
+        const defaultMonth = resolvedDefaultMonth;
         const fallbackLocationName = geocodeLocationSummary || geocodeDisplayName || propertyAddress;
         const normalizedLastUpdated = normalizeCrimeMonth(lastUpdatedDate) || lastUpdatedDate;
         const mapCenterOverride = hasUsableCoordinates(crimeLat, crimeLon)
@@ -9504,7 +9570,7 @@ export default function App() {
           mapCenterOverride,
         });
 
-        const monthCandidates = buildCrimeMonthRange(defaultMonth || lastUpdatedMonth || '');
+        const monthCandidates = buildCrimeMonthRange(defaultMonth || resolvedLatestMonth || '');
         if (defaultMonth && !monthCandidates.includes(defaultMonth)) {
           monthCandidates.unshift(defaultMonth);
         }
@@ -9756,12 +9822,13 @@ export default function App() {
               }
               const params = new URLSearchParams({
                 dataset,
-                point: `POINT(${normalizedLon.toFixed(6)} ${normalizedLat.toFixed(6)})`,
                 buffer: String(INFRASTRUCTURE_SEARCH_RADIUS_METERS),
                 limit: '50',
               });
+              params.set('point', `POINT(${normalizedLon.toFixed(6)} ${normalizedLat.toFixed(6)})`);
+              const queryString = params.toString().replace(/\+/g, '%20');
               const response = await fetch(
-                `https://www.planning.data.gov.uk/entity.json?${params.toString()}`,
+                `https://www.planning.data.gov.uk/entity.json?${queryString}`,
                 {
                   signal: controller.signal,
                   headers: { Accept: 'application/json' },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9365,7 +9365,7 @@ export default function App() {
           console.warn('Unable to fetch crime last-updated metadata:', error);
         }
 
-        const resolvedLatestMonth = clampCrimeMonthToLag(lastUpdatedMonth || lastUpdatedDate || '');
+        let resolvedLatestMonth = clampCrimeMonthToLag(lastUpdatedMonth || lastUpdatedDate || '');
 
         const createCrimeParams = (entries, options = {}) => {
           const params = new URLSearchParams();
@@ -9400,16 +9400,6 @@ export default function App() {
 
         const latParam = formatCoordinate(crimeLat);
         const lonParam = formatCoordinate(crimeLon);
-
-        const baseParams =
-          crimePostcodeQuery !== ''
-            ? createCrimeParams({ postcode: crimePostcodeQuery })
-            : createCrimeParams(
-                {
-                  lat: latParam,
-                  lng: lonParam,
-                }
-              );
 
         const fetchCrimesWithParams = async (searchParams) => {
           const url = `https://data.police.uk/api/crimes-street/all-crime?${searchParams.toString()}`;
@@ -9460,6 +9450,38 @@ export default function App() {
         let finalCrimeData = null;
         let finalError = null;
         let lastSuccessfulParams = null;
+        const boundingPolygon = geocodeBounds ? boundsToPolygon(geocodeBounds) : null;
+        const boundingPolygonParam = boundingPolygon ? polygonPointsToSearchParam(boundingPolygon) : '';
+        let cachedNeighbourhood = null;
+        let neighbourhoodAttempted = false;
+
+        const loadNeighbourhood = async () => {
+          if (neighbourhoodAttempted) {
+            return cachedNeighbourhood;
+          }
+          neighbourhoodAttempted = true;
+          try {
+            cachedNeighbourhood = await fetchNeighbourhoodBoundary({
+              lat: crimeLat,
+              lon: crimeLon,
+              postcode: geocodePostcode,
+              addressQuery: geocodeAddressQuery,
+              signal: controller.signal,
+            });
+          } catch (boundaryError) {
+            if (boundaryError?.name === 'AbortError') {
+              throw boundaryError;
+            }
+            if (!finalError) {
+              finalError =
+                boundaryError instanceof Error
+                  ? boundaryError
+                  : new Error('Unable to load local crime statistics.');
+            }
+            cachedNeighbourhood = null;
+          }
+          return cachedNeighbourhood;
+        };
 
         const attemptFetch = async (params, { boundsHint } = {}) => {
           try {
@@ -9484,57 +9506,98 @@ export default function App() {
           }
         };
 
-        finalCrimeData = await attemptFetch(baseParams, { boundsHint: geocodeBounds || null });
+        const tryCrimeStrategiesForMonth = async (monthValue) => {
+          const strategies = [];
+          const baseParams =
+            crimePostcodeQuery !== ''
+              ? createCrimeParams({ postcode: crimePostcodeQuery }, { date: monthValue })
+              : createCrimeParams({ lat: latParam, lng: lonParam }, { date: monthValue });
+          strategies.push({ params: baseParams, boundsHint: geocodeBounds || null });
 
-        if (!finalCrimeData && crimePostcodeQuery !== '' && hasUsableCoordinates(crimeLat, crimeLon)) {
-          const latLngParams = createCrimeParams({ lat: latParam, lng: lonParam });
-          finalCrimeData = await attemptFetch(latLngParams, { boundsHint: geocodeBounds || null });
-        }
+          if (crimePostcodeQuery !== '' && hasUsableCoordinates(crimeLat, crimeLon)) {
+            const latLngParams = createCrimeParams({ lat: latParam, lng: lonParam }, { date: monthValue });
+            strategies.push({ params: latLngParams, boundsHint: geocodeBounds || null });
+          }
 
-        if (!finalCrimeData && geocodeBounds) {
-          const boundingPolygon = boundsToPolygon(geocodeBounds);
-          if (boundingPolygon) {
-            const polyParams = createCrimeParams({ poly: boundingPolygon });
-            finalCrimeData = await attemptFetch(polyParams, { boundsHint: geocodeBounds });
+          if (boundingPolygonParam) {
+            const polygonParams = createCrimeParams({ poly: boundingPolygonParam }, { date: monthValue });
+            strategies.push({ params: polygonParams, boundsHint: geocodeBounds });
+          }
+
+          for (const strategy of strategies) {
+            const data = await attemptFetch(strategy.params, { boundsHint: strategy.boundsHint });
+            if (data) {
+              return data;
+            }
+          }
+
+          const neighbourhood = await loadNeighbourhood();
+          if (neighbourhood) {
+            const boundsHint = neighbourhood.bounds ?? geocodeBounds ?? null;
+            if (neighbourhood.locationId) {
+              const locationParams = createCrimeParams(
+                { location_id: neighbourhood.locationId },
+                { date: monthValue }
+              );
+              const locationData = await attemptFetch(locationParams, { boundsHint });
+              if (locationData) {
+                if (neighbourhood.bounds) {
+                  summaryBoundsHint = neighbourhood.bounds;
+                }
+                return locationData;
+              }
+            }
+            const neighbourhoodPolygon = polygonPointsToSearchParam(neighbourhood.points);
+            if (neighbourhoodPolygon) {
+              const neighbourhoodParams = createCrimeParams(
+                { poly: neighbourhoodPolygon },
+                { date: monthValue }
+              );
+              const polygonData = await attemptFetch(neighbourhoodParams, { boundsHint });
+              if (polygonData) {
+                if (neighbourhood.bounds) {
+                  summaryBoundsHint = neighbourhood.bounds;
+                }
+                return polygonData;
+              }
+            }
+          }
+
+          return null;
+        };
+
+        const normalizedBaseMonth = normalizeCrimeMonth(resolvedLatestMonth);
+        if (normalizedBaseMonth) {
+          resolvedLatestMonth = normalizedBaseMonth;
+        } else {
+          const fallbackMonth = normalizeCrimeMonth(computeCrimeLaggedMonth());
+          if (fallbackMonth) {
+            resolvedLatestMonth = fallbackMonth;
           }
         }
 
-        if (!finalCrimeData) {
-          try {
-            const neighbourhood = await fetchNeighbourhoodBoundary({
-              lat: crimeLat,
-              lon: crimeLon,
-              postcode: geocodePostcode,
-              addressQuery: geocodeAddressQuery,
-              signal: controller.signal,
-            });
-            if (neighbourhood) {
-              const boundsHint = neighbourhood.bounds ?? geocodeBounds ?? null;
-              if (!finalCrimeData && neighbourhood.locationId) {
-                const locationParams = createCrimeParams({ location_id: neighbourhood.locationId });
-                finalCrimeData = await attemptFetch(locationParams, { boundsHint });
-              }
-              if (!finalCrimeData) {
-                const polygonParam = polygonPointsToSearchParam(neighbourhood.points);
-                if (polygonParam) {
-                  const polyParams = createCrimeParams({ poly: polygonParam });
-                  finalCrimeData = await attemptFetch(polyParams, { boundsHint });
-                }
-              }
-              if (finalCrimeData && neighbourhood.bounds) {
-                summaryBoundsHint = neighbourhood.bounds;
-              }
+        const monthSearchOrderBase = normalizeCrimeMonth(resolvedLatestMonth);
+        const monthSearchOrder = monthSearchOrderBase
+          ? buildCrimeMonthRange(monthSearchOrderBase, CRIME_TREND_MAX_MONTHS)
+          : [];
+        if (monthSearchOrder.length === 0) {
+          monthSearchOrder.push('');
+        }
+
+        for (const monthValue of monthSearchOrder) {
+          const data = await tryCrimeStrategiesForMonth(monthValue);
+          if (controller.signal.aborted) {
+            return;
+          }
+          if (Array.isArray(data)) {
+            finalCrimeData = data;
+            const normalizedMonth = normalizeCrimeMonth(
+              monthValue || lastSuccessfulParams?.get('date') || resolvedLatestMonth
+            );
+            if (normalizedMonth) {
+              resolvedLatestMonth = normalizedMonth;
             }
-          } catch (boundaryError) {
-            if (boundaryError?.name === 'AbortError') {
-              throw boundaryError;
-            }
-            if (!finalError) {
-              finalError =
-                boundaryError instanceof Error
-                  ? boundaryError
-                  : new Error('Unable to load local crime statistics.');
-            }
+            break;
           }
         }
 
@@ -9601,7 +9664,14 @@ export default function App() {
 
         registerMonthSummary(defaultMonth || '', finalCrimeData, primarySummary);
 
-        const paramsTemplateString = (lastSuccessfulParams || baseParams).toString();
+        const paramsTemplateString =
+          lastSuccessfulParams?.toString() ||
+          createCrimeParams(
+            crimePostcodeQuery !== ''
+              ? { postcode: crimePostcodeQuery }
+              : { lat: latParam, lng: lonParam },
+            { date: defaultMonth || resolvedLatestMonth || '' }
+          ).toString();
 
         for (const monthValue of availableMonthValues) {
           if (!monthValue || monthValue === defaultMonth) {
@@ -9820,20 +9890,23 @@ export default function App() {
               if (!Number.isFinite(normalizedLat) || !Number.isFinite(normalizedLon)) {
                 throw new Error('Invalid property coordinates for planning lookup.');
               }
-              const params = new URLSearchParams({
-                dataset,
-                buffer: String(INFRASTRUCTURE_SEARCH_RADIUS_METERS),
-                limit: '50',
+              const wktPoint = `POINT (${normalizedLon.toFixed(6)} ${normalizedLat.toFixed(6)})`;
+              const queryString = [
+                ['dataset', dataset],
+                ['buffer', String(INFRASTRUCTURE_SEARCH_RADIUS_METERS)],
+                ['limit', '50'],
+                ['point', wktPoint],
+              ]
+                .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+                .join('&');
+              const url = `https://www.planning.data.gov.uk/entity.json?${queryString}`;
+              const response = await fetch(url, {
+                signal: controller.signal,
+                headers: { Accept: 'application/json' },
               });
-              params.set('point', `POINT(${normalizedLon.toFixed(6)} ${normalizedLat.toFixed(6)})`);
-              const queryString = params.toString().replace(/\+/g, '%20');
-              const response = await fetch(
-                `https://www.planning.data.gov.uk/entity.json?${queryString}`,
-                {
-                  signal: controller.signal,
-                  headers: { Accept: 'application/json' },
-                }
-              );
+              if (response.status === 422) {
+                return { key, items: [], error: '' };
+              }
               const rawBody = await response.text();
               if (!response.ok) {
                 let message = `Request failed with status ${response.status}`;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11604,11 +11604,13 @@ export default function App() {
       return [];
     }
     const irrHurdleBaseline = Number.isFinite(inputs.irrHurdle) ? inputs.irrHurdle : 0;
+    const bridgingActive = Boolean(inputs.useBridgingLoan);
     return LEVERAGE_LTV_OPTIONS.map((ltv) => {
       const depositPct = clamp(1 - ltv, 0, 1);
       const metrics = calculateEquity({
         ...inputs,
         depositPct,
+        ...(bridgingActive ? { bridgingLoanDepositPct: depositPct } : {}),
       });
       const roiValue = metrics.cashIn > 0 ? metrics.propertyNetWealthAtExit / metrics.cashIn - 1 : 0;
       const irrValue = Number(metrics.irr) || 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1625,6 +1625,8 @@ const DEFAULT_INPUTS = {
   bridgingLoanDepositPct: 0.25,
   bridgingValueAdded: 0,
   bridgingInterestPaymentMode: 'monthly',
+  capRateBenchmark: 0,
+  grmBenchmark: 0,
   monthlyRent: 800,
   vacancyPct: 0.05,
   mgmtPct: 0.1,
@@ -1659,6 +1661,10 @@ const EXTRA_SETTINGS_DEFAULTS = {
   indexFundGrowth: Number.isFinite(DEFAULT_INPUTS.indexFundGrowth)
     ? Number(DEFAULT_INPUTS.indexFundGrowth)
     : DEFAULT_INDEX_GROWTH,
+  capRateBenchmark: Number.isFinite(DEFAULT_INPUTS.capRateBenchmark)
+    ? Number(DEFAULT_INPUTS.capRateBenchmark)
+    : 0,
+  grmBenchmark: Number.isFinite(DEFAULT_INPUTS.grmBenchmark) ? Number(DEFAULT_INPUTS.grmBenchmark) : 0,
   deductOperatingExpenses: true,
 };
 
@@ -6380,9 +6386,6 @@ function calculateEquity(rawInputs) {
         }
       }
       if (month === monthsToModel) {
-        annualDebtService[yearIndex] += bridgingAmount;
-        annualPrincipal[yearIndex] += bridgingAmount;
-        annualBridgingDebtService[yearIndex] += bridgingAmount;
         if (bridgingInterestPaymentMode === 'roll_up' && accruedInterest !== 0) {
           annualDebtService[yearIndex] += accruedInterest;
           annualInterest[yearIndex] += accruedInterest;
@@ -14203,6 +14206,25 @@ export default function App() {
     );
   };
 
+  const extraSettingNumberInput = (key, label, step = 0.1, decimals = 2) => {
+    const rawValue = pendingExtraSettings?.[key];
+    const value = Number.isFinite(rawValue) ? rawValue : null;
+    return (
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-slate-600">{label}</label>
+        <input
+          type="number"
+          value={Number.isFinite(value) ? roundTo(value, decimals) : ''}
+          onChange={(event) =>
+            handlePendingExtraSettingChange(key, Number(event.target.value), decimals)
+          }
+          step={step}
+          className="w-full rounded-xl border border-slate-300 px-3 py-1.5 text-sm"
+        />
+      </div>
+    );
+  };
+
   const pctInput = (k, label, step = 0.005) => (
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-slate-600">{label}</label>
@@ -16019,7 +16041,7 @@ export default function App() {
                           {smallInput('bridgingLoanTermMonths', 'Bridging term (months)')}
                           {pctInput('bridgingLoanInterestRate', 'Bridging rate %', 0.001)}
                           {pctInput('bridgingLoanDepositPct', 'Bridge deposit %', 0.001)}
-                          {moneyInput('bridgingValueAdded', 'Value added after works (£)', 1000)}
+                          {moneyInput('bridgingValueAdded', 'Value added (£)', 1000)}
                         </div>
                         <div className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-white p-3 text-xs text-slate-700 sm:flex-row sm:items-center sm:justify-between">
                           <div className="font-semibold">Interest handling</div>
@@ -16036,7 +16058,7 @@ export default function App() {
                                   }))
                                 }
                               />
-                              <span>Pay interest monthly</span>
+                              <span>Monthly</span>
                             </label>
                             <label className="inline-flex items-center gap-2">
                               <input
@@ -16050,7 +16072,7 @@ export default function App() {
                                   }))
                                 }
                               />
-                              <span>Roll up and pay at exit</span>
+                              <span>Roll up</span>
                             </label>
                           </div>
                         </div>
@@ -16185,6 +16207,8 @@ export default function App() {
                     {extraSettingPctInput('discountRate', 'Discount rate %', 0.001)}
                     {extraSettingPctInput('irrHurdle', 'IRR hurdle %', 0.001)}
                     {extraSettingPctInput('indexFundGrowth', 'Index fund growth %')}
+                    {extraSettingPctInput('capRateBenchmark', 'Cap rate benchmark %', 0.001)}
+                    {extraSettingNumberInput('grmBenchmark', 'GRM benchmark')}
                     <div className="sm:col-span-2 rounded-xl border border-slate-200 p-3">
                       <label className="flex items-center gap-2 text-xs font-semibold text-slate-700">
                         <input
@@ -18281,8 +18305,8 @@ export default function App() {
                                 <dt>Interest handling</dt>
                                 <dd className="font-medium text-slate-800">
                                   {bridgingLoanSummary.interestMode === 'roll_up'
-                                    ? 'Roll up and pay at exit'
-                                    : 'Pay interest monthly'}
+                                    ? 'Roll up'
+                                    : 'Monthly'}
                                 </dd>
                               </div>
                               {bridgingLoanSummary.interestDuringTerm !== 0 ? (
@@ -19179,6 +19203,8 @@ export default function App() {
                     {pctInput('sellingCostsPct', 'Selling costs %')}
                     {extraSettingPctInput('discountRate', 'Discount rate %', 0.001)}
                     {extraSettingPctInput('irrHurdle', 'IRR hurdle %', 0.001)}
+                    {extraSettingPctInput('capRateBenchmark', 'Cap rate benchmark %', 0.001)}
+                    {extraSettingNumberInput('grmBenchmark', 'GRM benchmark')}
                   </div>
                 </div>
                 <div>
@@ -23718,7 +23744,7 @@ function PlanItemDetail({ item, onUpdate, onExitYearChange }) {
                 />
               </label>
               <label className="flex flex-col gap-1">
-                <span className="font-medium text-slate-600">Value added after works (£)</span>
+                <span className="font-medium text-slate-600">Value added (£)</span>
                 <input
                   type="number"
                   min={0}
@@ -23739,7 +23765,7 @@ function PlanItemDetail({ item, onUpdate, onExitYearChange }) {
                     checked={inputs.bridgingInterestPaymentMode !== 'roll_up'}
                     onChange={() => handleTextChange('bridgingInterestPaymentMode', 'monthly')}
                   />
-                  <span>Pay interest monthly</span>
+                  <span>Monthly</span>
                 </label>
                 <label className="inline-flex items-center gap-2">
                   <input
@@ -23748,7 +23774,7 @@ function PlanItemDetail({ item, onUpdate, onExitYearChange }) {
                     checked={inputs.bridgingInterestPaymentMode === 'roll_up'}
                     onChange={() => handleTextChange('bridgingInterestPaymentMode', 'roll_up')}
                   />
-                  <span>Roll up and pay at exit</span>
+                  <span>Roll up</span>
                 </label>
               </div>
             </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1622,6 +1622,9 @@ const DEFAULT_INPUTS = {
   useBridgingLoan: false,
   bridgingLoanTermMonths: 12,
   bridgingLoanInterestRate: 0.008,
+  bridgingLoanDepositPct: 0.25,
+  bridgingValueAdded: 0,
+  bridgingInterestPaymentMode: 'monthly',
   monthlyRent: 800,
   vacancyPct: 0.05,
   mgmtPct: 0.1,
@@ -4527,6 +4530,8 @@ const SECTION_DESCRIPTIONS = {
     'Summarises recent police-reported crime around the property and plots the incidents on an interactive map.',
   infrastructure:
     'Maps nearby planning applications and infrastructure projects so you can gauge future development activity around the property.',
+  bridgingSummary:
+    'Breaks down bridge funding assumptions, interest handling, post-refurbishment value, and refinance cash extracted once the bridge exits.',
   marketValue:
     'Compares cap rate, gross rent multiplier, discounted cash flow, and after-repair value signals to triangulate a fair market price.',
   investmentProfile:
@@ -6248,19 +6253,35 @@ function calculateEquity(rawInputs) {
   );
 
   const isCompanyBuyer = inputs.buyerType === 'company';
-  const deposit = inputs.purchasePrice * inputs.depositPct;
+  const baseDepositAmount = Math.max(0, inputs.purchasePrice * inputs.depositPct);
   const otherClosing = inputs.purchasePrice * inputs.closingCostsPct;
   const packageFees = Number(inputs.mortgagePackageFee ?? 0) || 0;
   const closing = otherClosing + packageFees + stampDuty;
 
-  const loan = inputs.purchasePrice - deposit;
+  const bridgingEnabled = Boolean(inputs.useBridgingLoan);
+  const rawBridgingDepositPct = Number(inputs.bridgingLoanDepositPct ?? inputs.depositPct ?? 0);
+  const bridgingDepositShare = bridgingEnabled
+    ? clamp(Number.isFinite(rawBridgingDepositPct) ? rawBridgingDepositPct : inputs.depositPct || 0, 0, 0.95)
+    : inputs.depositPct;
+  const bridgingDepositAmount = bridgingEnabled
+    ? Math.min(inputs.purchasePrice, Math.max(0, inputs.purchasePrice * bridgingDepositShare))
+    : baseDepositAmount;
+  const bridgingValueAddedRaw = Number(inputs.bridgingValueAdded ?? 0);
+  const bridgingValueAdded =
+    bridgingEnabled && Number.isFinite(bridgingValueAddedRaw) ? bridgingValueAddedRaw : 0;
+  const postBridgeValue = bridgingEnabled
+    ? Math.max(0, inputs.purchasePrice + bridgingValueAdded)
+    : inputs.purchasePrice;
+  const permanentDepositAmount = Math.max(0, postBridgeValue * inputs.depositPct);
+  const deposit = bridgingEnabled ? bridgingDepositAmount : baseDepositAmount;
+
+  const loan = Math.max(0, postBridgeValue - permanentDepositAmount);
   const irrHurdleValue = Number.isFinite(inputs.irrHurdle) ? inputs.irrHurdle : 0;
   const mortgageMonthly =
     inputs.loanType === 'interest_only'
       ? (loan * inputs.interestRate) / 12
       : monthlyMortgagePayment({ principal: loan, annualRate: inputs.interestRate, years: inputs.mortgageYears });
 
-  const bridgingEnabled = Boolean(inputs.useBridgingLoan);
   const rawBridgingTerm = Number(inputs.bridgingLoanTermMonths ?? 0);
   const bridgingLoanTermMonths =
     bridgingEnabled && Number.isFinite(rawBridgingTerm)
@@ -6273,10 +6294,12 @@ function calculateEquity(rawInputs) {
     bridgingEnabled && Number.isFinite(rawBridgingRate)
       ? Math.max(0, rawBridgingRate)
       : 0;
-  const bridgingAmount = bridgingEnabled ? deposit : 0;
+  const bridgingInterestPaymentMode =
+    bridgingEnabled && inputs.bridgingInterestPaymentMode === 'roll_up' ? 'roll_up' : 'monthly';
+  const bridgingAmount = bridgingEnabled ? Math.max(0, inputs.purchasePrice - bridgingDepositAmount) : 0;
   const totalCashRequired = deposit + closing + inputs.renovationCost;
-  const initialCashOutlay = Math.max(totalCashRequired - bridgingAmount, 0);
-  const indexInitialInvestment = bridgingEnabled ? deposit : initialCashOutlay;
+  const initialCashOutlay = totalCashRequired;
+  const indexInitialInvestment = totalCashRequired;
 
   const baseIncome1 = isCompanyBuyer ? 0 : (inputs.incomePerson1 ?? 0);
   const baseIncome2 = isCompanyBuyer ? 0 : (inputs.incomePerson2 ?? 0);
@@ -6291,6 +6314,8 @@ function calculateEquity(rawInputs) {
   const annualInterest = Array.from({ length: inputs.exitYear }, () => 0);
   const annualPrincipal = Array.from({ length: inputs.exitYear }, () => 0);
   const annualBridgingDebtService = Array.from({ length: inputs.exitYear }, () => 0);
+  let bridgingInterestPaidDuringTerm = 0;
+  let bridgingInterestPaidAtExit = 0;
   const monthlyRate = inputs.interestRate / 12;
   let balance = loan;
   const totalMonths = inputs.exitYear * 12;
@@ -6338,22 +6363,45 @@ function calculateEquity(rawInputs) {
     const monthsToModel = Math.min(bridgingLoanTermMonths, inputs.exitYear * 12);
     const monthlyInterest =
       bridgingMonthlyRate > 0 ? bridgingAmount * bridgingMonthlyRate : 0;
+    let accruedInterest = 0;
     for (let month = 1; month <= monthsToModel; month++) {
       const yearIndex = Math.ceil(month / 12) - 1;
       if (yearIndex < 0 || yearIndex >= annualDebtService.length) {
         continue;
       }
       if (monthlyInterest !== 0) {
-        annualDebtService[yearIndex] += monthlyInterest;
-        annualInterest[yearIndex] += monthlyInterest;
-        annualBridgingDebtService[yearIndex] += monthlyInterest;
+        if (bridgingInterestPaymentMode === 'monthly') {
+          annualDebtService[yearIndex] += monthlyInterest;
+          annualInterest[yearIndex] += monthlyInterest;
+          annualBridgingDebtService[yearIndex] += monthlyInterest;
+          bridgingInterestPaidDuringTerm += monthlyInterest;
+        } else {
+          accruedInterest += monthlyInterest;
+        }
       }
       if (month === monthsToModel) {
         annualDebtService[yearIndex] += bridgingAmount;
         annualPrincipal[yearIndex] += bridgingAmount;
+        annualBridgingDebtService[yearIndex] += bridgingAmount;
+        if (bridgingInterestPaymentMode === 'roll_up' && accruedInterest !== 0) {
+          annualDebtService[yearIndex] += accruedInterest;
+          annualInterest[yearIndex] += accruedInterest;
+          annualBridgingDebtService[yearIndex] += accruedInterest;
+          bridgingInterestPaidAtExit += accruedInterest;
+        }
       }
     }
   }
+
+  const bridgingInterestTotal = bridgingInterestPaidDuringTerm + bridgingInterestPaidAtExit;
+  const bridgingExitPayoff = bridgingAmount + bridgingInterestPaidAtExit;
+  const totalCashInvestedDuringBridge = bridgingEnabled
+    ? totalCashRequired + bridgingInterestPaidDuringTerm
+    : 0;
+  const refinanceCashAvailable = bridgingEnabled ? loan - bridgingExitPayoff : 0;
+  const netCashAfterRefinance = bridgingEnabled
+    ? refinanceCashAvailable - totalCashInvestedDuringBridge
+    : 0;
 
   const grossRentYear1 = inputs.monthlyRent * 12 * (1 - inputs.vacancyPct);
   const variableOpex = inputs.monthlyRent * 12 * (inputs.mgmtPct + inputs.repairsPct);
@@ -6937,6 +6985,20 @@ function calculateEquity(rawInputs) {
     bridgingLoanAmount: bridgingAmount,
     bridgingLoanTermMonths,
     bridgingLoanInterestRate: bridgingMonthlyRate,
+    bridgingLoanDepositPct: bridgingEnabled ? bridgingDepositShare : inputs.depositPct,
+    bridgingDepositAmount: bridgingEnabled ? deposit : 0,
+    bridgingInterestPaymentMode,
+    bridgingInterestPaidDuringTerm,
+    bridgingInterestPaidAtExit,
+    bridgingInterestTotal,
+    bridgingExitPayoff,
+    bridgingValueAdded: bridgingEnabled ? bridgingValueAdded : 0,
+    postBridgeValue,
+    permanentDepositAmount,
+    permanentLoanAmount: loan,
+    refinanceCashAvailable,
+    totalCashInvestedDuringBridge,
+    netCashAfterRefinance,
     projectCost,
     yoc: noiYear1 / (inputs.purchasePrice + closing + inputs.renovationCost),
     indexValEnd: indexVal,
@@ -7830,6 +7892,7 @@ export default function App() {
     equityGrowth: true,
     interestSplit: true,
     leverage: true,
+    bridgingSummary: false,
     marketValue: true,
     investmentProfile: true,
   });
@@ -12512,6 +12575,59 @@ export default function App() {
     inputs.exitYear,
     inputs.renovationCost,
   ]);
+  const bridgingLoanSummary = useMemo(() => {
+    if (!inputs.useBridgingLoan || !equity) {
+      return null;
+    }
+
+    const depositAmount = Number(equity.deposit) || 0;
+    const bridgeDepositPct = Number.isFinite(equity.bridgingLoanDepositPct)
+      ? equity.bridgingLoanDepositPct
+      : Number(inputs.bridgingLoanDepositPct ?? inputs.depositPct ?? 0) || 0;
+    const bridgingLoanAmount = Number(equity.bridgingLoanAmount) || 0;
+    const interestMode = equity.bridgingInterestPaymentMode === 'roll_up' ? 'roll_up' : 'monthly';
+    const interestDuringTerm = Number(equity.bridgingInterestPaidDuringTerm) || 0;
+    const interestAtExit = Number(equity.bridgingInterestPaidAtExit) || 0;
+    const interestTotalValue = Number(equity.bridgingInterestTotal) || interestDuringTerm + interestAtExit;
+    const bridgePayoff = Number(equity.bridgingExitPayoff) || bridgingLoanAmount + interestAtExit;
+    const cashRequired = Number(equity.cashIn) || 0;
+    const totalInvested = Number(equity.totalCashInvestedDuringBridge) || cashRequired + interestDuringTerm;
+    const valueAdded = Number(equity.bridgingValueAdded) || 0;
+    const postBridgeValue = Number(equity.postBridgeValue) || Number(inputs.purchasePrice) + valueAdded;
+    const permanentDeposit = Number(equity.permanentDepositAmount) || 0;
+    const permanentLoan = Number(equity.permanentLoanAmount ?? equity.loan) || 0;
+    const refinanceCash = Number(equity.refinanceCashAvailable);
+    const refinanceCashAvailable = Number.isFinite(refinanceCash) ? refinanceCash : permanentLoan - bridgePayoff;
+    const netCash = Number(equity.netCashAfterRefinance);
+    const netCashAfterRefinance = Number.isFinite(netCash) ? netCash : refinanceCashAvailable - totalInvested;
+    const normalizedBridgePct = clamp(bridgeDepositPct, 0, 1);
+    const refinanceLtv = postBridgeValue > 0 ? permanentLoan / postBridgeValue : null;
+    return {
+      depositAmount,
+      bridgeDepositPct: normalizedBridgePct,
+      bridgingLoanAmount,
+      interestMode,
+      interestDuringTerm,
+      interestAtExit,
+      interestTotalValue,
+      bridgePayoff,
+      cashRequired,
+      totalInvested,
+      valueAdded,
+      postBridgeValue,
+      permanentDeposit,
+      permanentLoan,
+      refinanceCashAvailable,
+      netCashAfterRefinance,
+      refinanceLtv,
+    };
+  }, [
+    inputs.useBridgingLoan,
+    inputs.bridgingLoanDepositPct,
+    inputs.depositPct,
+    inputs.purchasePrice,
+    equity,
+  ]);
   const investmentProfile = useMemo(() => {
     if (!equity) {
       return null;
@@ -15895,18 +16011,54 @@ export default function App() {
                           }))
                         }
                       />
-                      <span>Use bridging loan for deposit</span>
+                      <span>Use bridging loan to complete purchase</span>
                     </label>
                     {inputs.useBridgingLoan ? (
-                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                        {smallInput('bridgingLoanTermMonths', 'Bridging term (months)')}
-                        {pctInput('bridgingLoanInterestRate', 'Bridging rate %', 0.001)}
+                      <div className="space-y-2">
+                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                          {smallInput('bridgingLoanTermMonths', 'Bridging term (months)')}
+                          {pctInput('bridgingLoanInterestRate', 'Bridging rate %', 0.001)}
+                          {pctInput('bridgingLoanDepositPct', 'Bridge deposit %', 0.001)}
+                          {moneyInput('bridgingValueAdded', 'Value added after works (£)', 1000)}
+                        </div>
+                        <div className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-white p-3 text-xs text-slate-700 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="font-semibold">Interest handling</div>
+                          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+                            <label className="inline-flex items-center gap-2">
+                              <input
+                                type="radio"
+                                name="bridgingInterestMode"
+                                checked={inputs.bridgingInterestPaymentMode !== 'roll_up'}
+                                onChange={() =>
+                                  setInputs((prev) => ({
+                                    ...prev,
+                                    bridgingInterestPaymentMode: 'monthly',
+                                  }))
+                                }
+                              />
+                              <span>Pay interest monthly</span>
+                            </label>
+                            <label className="inline-flex items-center gap-2">
+                              <input
+                                type="radio"
+                                name="bridgingInterestMode"
+                                checked={inputs.bridgingInterestPaymentMode === 'roll_up'}
+                                onChange={() =>
+                                  setInputs((prev) => ({
+                                    ...prev,
+                                    bridgingInterestPaymentMode: 'roll_up',
+                                  }))
+                                }
+                              />
+                              <span>Roll up and pay at exit</span>
+                            </label>
+                          </div>
+                        </div>
+                        <p className="text-[11px] text-slate-500">
+                          The bridge funds the purchase price minus your bridge deposit for the term selected before switching to
+                          the standard mortgage. Any value added is applied to the refinance valuation once the bridge ends.
+                        </p>
                       </div>
-                    ) : null}
-                    {inputs.useBridgingLoan ? (
-                      <p className="text-[11px] text-slate-500">
-                        Deposit funds are covered by the bridge during the selected term before reverting to the standard mortgage.
-                      </p>
                     ) : null}
                   </div>
                 </div>
@@ -18066,6 +18218,163 @@ export default function App() {
                   </>
                 ) : null}
               </div>
+              {inputs.useBridgingLoan ? (
+                <div
+                  className={`rounded-2xl bg-white p-3 shadow-sm ${
+                    collapsedSections.bridgingSummary ? 'md:col-span-1' : 'md:col-span-2'
+                  }`}
+                >
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => toggleSection('bridgingSummary')}
+                        aria-expanded={!collapsedSections.bridgingSummary}
+                        className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                        aria-label={
+                          collapsedSections.bridgingSummary
+                            ? 'Show bridging finance summary'
+                            : 'Hide bridging finance summary'
+                        }
+                      >
+                        {collapsedSections.bridgingSummary ? '+' : '−'}
+                      </button>
+                      <SectionTitle
+                        label="Bridging finance"
+                        tooltip={SECTION_DESCRIPTIONS.bridgingSummary}
+                        className="text-sm font-semibold text-slate-700"
+                      />
+                    </div>
+                  </div>
+                  {!collapsedSections.bridgingSummary ? (
+                    <>
+                      <p className="mb-3 text-[11px] text-slate-500">
+                        Track the bridge set-up, interest handling, and refinance outcome to understand total bridge cost and
+                        how much equity you can recycle when the loan converts to standard financing.
+                      </p>
+                      {bridgingLoanSummary ? (
+                        <div className="grid gap-3 md:grid-cols-2">
+                          <div className="h-full rounded-xl border border-slate-200 bg-slate-50 p-3">
+                            <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Bridge facility</h4>
+                            <dl className="mt-2 space-y-1 text-[11px] text-slate-600">
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Bridge deposit</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.depositAmount)} ({formatPercent(
+                                    bridgingLoanSummary.bridgeDepositPct
+                                  )})
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Cash required upfront</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.cashRequired)}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Bridge loan amount</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.bridgingLoanAmount)}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Interest handling</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {bridgingLoanSummary.interestMode === 'roll_up'
+                                    ? 'Roll up and pay at exit'
+                                    : 'Pay interest monthly'}
+                                </dd>
+                              </div>
+                              {bridgingLoanSummary.interestDuringTerm !== 0 ? (
+                                <div className="flex items-center justify-between gap-2">
+                                  <dt>Interest paid during term</dt>
+                                  <dd className="font-medium text-slate-800">
+                                    {currency(bridgingLoanSummary.interestDuringTerm)}
+                                  </dd>
+                                </div>
+                              ) : null}
+                              {bridgingLoanSummary.interestAtExit !== 0 ? (
+                                <div className="flex items-center justify-between gap-2">
+                                  <dt>Interest paid at exit</dt>
+                                  <dd className="font-medium text-slate-800">
+                                    {currency(bridgingLoanSummary.interestAtExit)}
+                                  </dd>
+                                </div>
+                              ) : null}
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Total interest cost</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.interestTotalValue)}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Bridge payoff at refinance</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.bridgePayoff)}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Total cash invested (bridge stage)</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.totalInvested)}
+                                </dd>
+                              </div>
+                            </dl>
+                          </div>
+                          <div className="h-full rounded-xl border border-slate-200 bg-slate-50 p-3">
+                            <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Refinance outlook</h4>
+                            <dl className="mt-2 space-y-1 text-[11px] text-slate-600">
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Value added before refinance</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.valueAdded)}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Post-bridge valuation</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.postBridgeValue)}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Permanent deposit requirement</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.permanentDeposit)}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Permanent loan after refinance</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.permanentLoan)}
+                                  {Number.isFinite(bridgingLoanSummary.refinanceLtv)
+                                    ? ` (${formatPercent(bridgingLoanSummary.refinanceLtv)} LTV)`
+                                    : ''}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Cash after repaying bridge</dt>
+                                <dd className="font-medium text-slate-800">
+                                  {currency(bridgingLoanSummary.refinanceCashAvailable)}
+                                </dd>
+                              </div>
+                              <div className="flex items-center justify-between gap-2">
+                                <dt>Net cash after reimbursing costs</dt>
+                                <dd className={`font-medium ${bridgingLoanSummary.netCashAfterRefinance >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>
+                                  {currency(bridgingLoanSummary.netCashAfterRefinance)}
+                                </dd>
+                              </div>
+                            </dl>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="rounded-xl border border-dashed border-slate-200 p-3 text-center text-[11px] text-slate-500">
+                          Provide bridge term, rate, deposit, and value-add assumptions to model the refinance.
+                        </div>
+                      )}
+                    </>
+                  ) : null}
+                </div>
+              ) : null}
               <div
                 className={`rounded-2xl bg-white p-3 shadow-sm ${
                   collapsedSections.marketValue ? 'md:col-span-1' : 'md:col-span-2'
@@ -23369,32 +23678,84 @@ function PlanItemDetail({ item, onUpdate, onExitYearChange }) {
             checked={bridgingChecked}
             onChange={(event) => handleCheckboxChange('useBridgingLoan', event.target.checked)}
           />
-          <span>Use bridging loan for deposit</span>
+          <span>Use bridging loan to complete purchase</span>
         </label>
         {bridgingChecked ? (
-          <div className="mt-2 grid gap-2 md:grid-cols-2">
-            <label className="flex flex-col gap-1">
-              <span className="font-medium text-slate-600">Bridging term (months)</span>
-              <input
-                type="number"
-                min={1}
-              value={numericValue('bridgingLoanTermMonths')}
-                onChange={(event) => handleNumberChange('bridgingLoanTermMonths', event.target.value)}
-                className="rounded-lg border border-slate-300 px-3 py-1.5"
-              />
-            </label>
-            <label className="flex flex-col gap-1">
-              <span className="font-medium text-slate-600">Bridging rate %</span>
-              <input
-                type="number"
-                min={0}
-                max={100}
-                step={0.01}
-                value={percentValue('bridgingLoanInterestRate')}
-                onChange={(event) => handlePercentChange('bridgingLoanInterestRate', event.target.value)}
-                className="rounded-lg border border-slate-300 px-3 py-1.5"
-              />
-            </label>
+          <div className="mt-2 space-y-3">
+            <div className="grid gap-2 md:grid-cols-2">
+              <label className="flex flex-col gap-1">
+                <span className="font-medium text-slate-600">Bridging term (months)</span>
+                <input
+                  type="number"
+                  min={1}
+                  value={numericValue('bridgingLoanTermMonths')}
+                  onChange={(event) => handleNumberChange('bridgingLoanTermMonths', event.target.value)}
+                  className="rounded-lg border border-slate-300 px-3 py-1.5"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-medium text-slate-600">Bridging rate %</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.01}
+                  value={percentValue('bridgingLoanInterestRate')}
+                  onChange={(event) => handlePercentChange('bridgingLoanInterestRate', event.target.value)}
+                  className="rounded-lg border border-slate-300 px-3 py-1.5"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-medium text-slate-600">Bridge deposit %</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.01}
+                  value={percentValue('bridgingLoanDepositPct')}
+                  onChange={(event) => handlePercentChange('bridgingLoanDepositPct', event.target.value)}
+                  className="rounded-lg border border-slate-300 px-3 py-1.5"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-medium text-slate-600">Value added after works (£)</span>
+                <input
+                  type="number"
+                  min={0}
+                  step={1000}
+                  value={numericValue('bridgingValueAdded')}
+                  onChange={(event) => handleNumberChange('bridgingValueAdded', event.target.value)}
+                  className="rounded-lg border border-slate-300 px-3 py-1.5"
+                />
+              </label>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-white p-3 text-xs text-slate-700">
+              <div className="font-semibold">Interest handling</div>
+              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name={`${loanTypeName}-bridge-interest`}
+                    checked={inputs.bridgingInterestPaymentMode !== 'roll_up'}
+                    onChange={() => handleTextChange('bridgingInterestPaymentMode', 'monthly')}
+                  />
+                  <span>Pay interest monthly</span>
+                </label>
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name={`${loanTypeName}-bridge-interest`}
+                    checked={inputs.bridgingInterestPaymentMode === 'roll_up'}
+                    onChange={() => handleTextChange('bridgingInterestPaymentMode', 'roll_up')}
+                  />
+                  <span>Roll up and pay at exit</span>
+                </label>
+              </div>
+            </div>
+            <p className="text-[11px] text-slate-500">
+              The bridge covers the purchase price less your selected bridge deposit during the term before converting to your
+              standard mortgage. Added value is included in the refinance valuation once the bridge ends.
+            </p>
           </div>
         ) : null}
       </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17554,33 +17554,35 @@ export default function App() {
                         className="text-sm font-semibold text-slate-700"
                       />
                     </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      {crimeAvailableMonths.length > 0 ? (
-                        <label
-                          htmlFor="crime-month-select"
-                          className="flex items-center gap-2 text-[11px] text-slate-500"
-                        >
-                          <span>Reporting period</span>
-                          <select
-                            id="crime-month-select"
-                            value={crimeSelectValue}
-                            onChange={(event) => setCrimeSelectedMonth(event.target.value)}
-                            className="rounded-lg border border-slate-300 px-2 py-1 text-xs text-slate-700"
+                    {!collapsedSections.crime ? (
+                      <div className="flex flex-wrap items-center gap-2">
+                        {crimeAvailableMonths.length > 0 ? (
+                          <label
+                            htmlFor="crime-month-select"
+                            className="flex items-center gap-2 text-[11px] text-slate-500"
                           >
-                            {crimeAvailableMonths.map((option) => (
-                              <option key={`crime-month-${option.value}`} value={option.value}>
-                                {option.label}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      ) : null}
-                      {crimeLoading ? (
-                        <span className="text-[11px] text-slate-500">Loading…</span>
-                      ) : crimePeriodDescription ? (
-                        <span className="text-[11px] text-slate-500">Period: {crimePeriodDescription}</span>
-                      ) : null}
-                    </div>
+                            <span>Reporting period</span>
+                            <select
+                              id="crime-month-select"
+                              value={crimeSelectValue}
+                              onChange={(event) => setCrimeSelectedMonth(event.target.value)}
+                              className="rounded-lg border border-slate-300 px-2 py-1 text-xs text-slate-700"
+                            >
+                              {crimeAvailableMonths.map((option) => (
+                                <option key={`crime-month-${option.value}`} value={option.value}>
+                                  {option.label}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                        ) : null}
+                        {crimeLoading ? (
+                          <span className="text-[11px] text-slate-500">Loading…</span>
+                        ) : crimePeriodDescription ? (
+                          <span className="text-[11px] text-slate-500">Period: {crimePeriodDescription}</span>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </div>
                   {!collapsedSections.crime ? (
                     <div className="space-y-4">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -354,6 +354,22 @@ const toFiniteNumber = (value, fallback = 0) => {
   return Number.isFinite(number) ? number : fallback;
 };
 
+const pickFirstFinite = (...candidates) => {
+  for (const candidate of candidates) {
+    if (candidate === null || candidate === undefined) {
+      continue;
+    }
+    if (typeof candidate === 'string' && candidate.trim() === '') {
+      continue;
+    }
+    const numeric = Number(candidate);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+  }
+  return null;
+};
+
 const mergeLegendPayload = (payload, entries) => {
   const base = Array.isArray(payload) ? [...payload] : [];
   if (!Array.isArray(entries) || entries.length === 0) {
@@ -4511,6 +4527,8 @@ const SECTION_DESCRIPTIONS = {
     'Summarises recent police-reported crime around the property and plots the incidents on an interactive map.',
   infrastructure:
     'Maps nearby planning applications and infrastructure projects so you can gauge future development activity around the property.',
+  marketValue:
+    'Compares cap rate, gross rent multiplier, discounted cash flow, and after-repair value signals to triangulate a fair market price.',
   investmentProfile:
     'Synthesises IRR, cash-on-cash return, and discounted net present value into a narrative on overall deal quality.',
 };
@@ -7812,6 +7830,7 @@ export default function App() {
     equityGrowth: true,
     interestSplit: true,
     leverage: true,
+    marketValue: true,
     investmentProfile: true,
   });
   const [showInvestmentProfileDetails, setShowInvestmentProfileDetails] = useState(false);
@@ -12214,6 +12233,284 @@ export default function App() {
     propertyNetAfterTaxLabel,
     rentalTaxLabel,
     rentalTaxCumulativeLabel,
+  ]);
+  const marketValueSummary = useMemo(() => {
+    if (!equity) {
+      return null;
+    }
+
+    const purchasePriceNumeric = Number(inputs.purchasePrice);
+    const purchasePrice = Number.isFinite(purchasePriceNumeric) ? purchasePriceNumeric : null;
+    const noiValue = Number.isFinite(equity.noiYear1) ? equity.noiYear1 : null;
+    const subjectCapRate = Number.isFinite(equity.cap) ? equity.cap : null;
+    const providedCapRateBenchmark = pickFirstFinite(
+      inputs.marketCapRate,
+      inputs.capRateBenchmark,
+      inputs.targetCapRate,
+      inputs.capRateAssumption,
+      inputs.capRateMarket,
+      inputs.marketCapRatePct,
+      inputs.capRate
+    );
+    const capRateFromSubject =
+      (!Number.isFinite(providedCapRateBenchmark) || providedCapRateBenchmark <= 0) &&
+      Number.isFinite(subjectCapRate) &&
+      subjectCapRate > 0;
+    const capRateAssumption =
+      Number.isFinite(providedCapRateBenchmark) && providedCapRateBenchmark > 0
+        ? providedCapRateBenchmark
+        : capRateFromSubject
+        ? subjectCapRate
+        : null;
+    const capMarketValue =
+      Number.isFinite(noiValue) && Number.isFinite(capRateAssumption) && capRateAssumption > 0
+        ? noiValue / capRateAssumption
+        : null;
+    const capDifference =
+      Number.isFinite(capMarketValue) && Number.isFinite(purchasePrice) ? capMarketValue - purchasePrice : null;
+    const capNote = !Number.isFinite(capRateAssumption)
+      ? 'Provide a market cap rate benchmark to price the income stream.'
+      : capRateFromSubject
+      ? 'Using the scenario cap rate because no market benchmark was provided.'
+      : '';
+
+    const monthlyRent = Number(inputs.monthlyRent);
+    const vacancy = Number(inputs.vacancyPct);
+    const vacancyRate = Number.isFinite(vacancy) ? clamp(vacancy, 0, 0.95) : 0;
+    const grossAnnualRent = Number.isFinite(monthlyRent)
+      ? monthlyRent * 12 * (1 - vacancyRate)
+      : Number.isFinite(equity.grossRentYear1)
+      ? equity.grossRentYear1
+      : null;
+    const subjectGrm =
+      Number.isFinite(grossAnnualRent) && grossAnnualRent > 0 && Number.isFinite(purchasePrice) && purchasePrice > 0
+        ? purchasePrice / grossAnnualRent
+        : null;
+    const providedGrmBenchmark = pickFirstFinite(
+      inputs.marketGrm,
+      inputs.grossRentMultiplier,
+      inputs.targetGrm,
+      inputs.marketGrossRentMultiplier,
+      inputs.grmBenchmark,
+      inputs.grmAssumption,
+      inputs.grossRentMultiple
+    );
+    const grmFromSubject =
+      (!Number.isFinite(providedGrmBenchmark) || providedGrmBenchmark <= 0) &&
+      Number.isFinite(subjectGrm) &&
+      subjectGrm > 0;
+    const grmAssumption =
+      Number.isFinite(providedGrmBenchmark) && providedGrmBenchmark > 0
+        ? providedGrmBenchmark
+        : grmFromSubject
+        ? subjectGrm
+        : null;
+    const grmMarketValue =
+      Number.isFinite(grossAnnualRent) && Number.isFinite(grmAssumption) && grmAssumption > 0
+        ? grossAnnualRent * grmAssumption
+        : null;
+    const grmDifference =
+      Number.isFinite(grmMarketValue) && Number.isFinite(purchasePrice) ? grmMarketValue - purchasePrice : null;
+    const grmNote = !Number.isFinite(grmAssumption)
+      ? 'Provide a market gross rent multiplier from comparable sales to use this view.'
+      : grmFromSubject
+      ? 'Using the scenario rent and price to infer the GRM because no market benchmark was provided.'
+      : '';
+
+    const npvValue = Number.isFinite(equity.npv) ? equity.npv : null;
+    const initialOutlay = pickFirstFinite(equity.initialCashOutlay, equity.cashIn);
+    const discountRateValue = Number.isFinite(inputs.discountRate) ? inputs.discountRate : null;
+    const dcfMarketValue =
+      Number.isFinite(npvValue) && Number.isFinite(initialOutlay) ? npvValue + initialOutlay : null;
+    const dcfDifference =
+      Number.isFinite(dcfMarketValue) && Number.isFinite(purchasePrice) ? dcfMarketValue - purchasePrice : null;
+    const dcfNote = !Number.isFinite(dcfMarketValue)
+      ? 'Model discounted cash flow by providing a discount rate and hold assumptions.'
+      : '';
+
+    const arvCandidate = pickFirstFinite(
+      inputs.afterRepairValue,
+      inputs.arv,
+      inputs.estimatedArv,
+      inputs.postRenovationValue,
+      inputs.projectedArv,
+      inputs.expectedArv,
+      inputs.arvEstimate,
+      inputs.afterRenovationValue,
+      inputs.futureSaleValue,
+      inputs.renovationArv,
+      inputs.brArv
+    );
+    let arvSource = 'assumption';
+    let arvValue = Number.isFinite(arvCandidate) ? arvCandidate : null;
+    if (!Number.isFinite(arvValue) && Number.isFinite(equity.futureValue)) {
+      arvValue = equity.futureValue;
+      arvSource = 'projection';
+    }
+    const arvDifference =
+      Number.isFinite(arvValue) && Number.isFinite(purchasePrice) ? arvValue - purchasePrice : null;
+    const arvNote = !Number.isFinite(arvValue)
+      ? 'Add an after-repair value assumption or comparable to benchmark uplift potential.'
+      : arvSource === 'projection'
+      ? `Using year ${Math.max(1, Number(inputs.exitYear) || 1)} exit projection because no ARV assumption was provided.`
+      : '';
+
+    const renovationBudget = Number.isFinite(inputs.renovationCost) ? inputs.renovationCost : null;
+
+    const factors = [
+      {
+        key: 'capRate',
+        label: 'Capitalization Rate (Cap Rate)',
+        formula: 'Market Value = NOI ÷ Cap Rate',
+        purpose:
+          'The most widely used income-based valuation metric. It prices a property based on how much income it generates relative to similar assets in the market.',
+        usedBy: 'Institutional and buy-to-let investors, valuers, lenders.',
+        impliedValue: capMarketValue,
+        difference: capDifference,
+        available: Number.isFinite(capMarketValue),
+        note: capNote,
+        details: [
+          Number.isFinite(noiValue)
+            ? { label: 'Year-one NOI', value: currency(noiValue) }
+            : null,
+          Number.isFinite(capRateAssumption)
+            ? { label: 'Benchmark cap rate', value: formatPercent(capRateAssumption) }
+            : null,
+          Number.isFinite(subjectCapRate)
+            ? { label: 'Scenario cap rate', value: formatPercent(subjectCapRate) }
+            : null,
+        ].filter(Boolean),
+      },
+      {
+        key: 'grm',
+        label: 'Gross Rent Multiplier (GRM)',
+        formula: 'Market Value = Gross Annual Rent × GRM',
+        purpose:
+          'A simpler proxy for market value when full expense data is unavailable. It reflects local investor sentiment on how much they will pay per pound of rent.',
+        usedBy: 'Residential investors, estate agents.',
+        impliedValue: grmMarketValue,
+        difference: grmDifference,
+        available: Number.isFinite(grmMarketValue),
+        note: grmNote,
+        details: [
+          Number.isFinite(grossAnnualRent)
+            ? { label: 'Gross annual rent (vacancy-adjusted)', value: currency(grossAnnualRent) }
+            : null,
+          Number.isFinite(grmAssumption)
+            ? { label: 'GRM benchmark', value: grmAssumption.toFixed(2) }
+            : null,
+          Number.isFinite(subjectGrm)
+            ? { label: 'Scenario GRM', value: subjectGrm.toFixed(2) }
+            : null,
+        ].filter(Boolean),
+      },
+      {
+        key: 'dcf',
+        label: 'Discounted Cash Flow (DCF) / Net Present Value (NPV)',
+        formula: 'Market Value = Σ CFₜ / (1 + r)ᵗ',
+        purpose:
+          'Determines intrinsic market value based on expected future cashflows discounted to today’s terms.',
+        usedBy: 'Commercial investors and analysts valuing large assets.',
+        impliedValue: dcfMarketValue,
+        difference: dcfDifference,
+        available: Number.isFinite(dcfMarketValue),
+        note: dcfNote,
+        details: [
+          Number.isFinite(discountRateValue)
+            ? { label: 'Discount rate', value: formatPercent(discountRateValue) }
+            : null,
+          Number.isFinite(npvValue) ? { label: 'Discounted NPV', value: currency(npvValue) } : null,
+          Number.isFinite(initialOutlay)
+            ? { label: 'Initial cash invested', value: currency(initialOutlay) }
+            : null,
+        ].filter(Boolean),
+      },
+      {
+        key: 'arv',
+        label: 'After-Repair Value (ARV)',
+        formula: 'Definition: Estimated market value post-renovation based on comparable upgraded sales.',
+        purpose:
+          'Used to forecast the market value after capital expenditure or BRR strategies.',
+        usedBy: 'BRR, flip, and development investors.',
+        impliedValue: Number.isFinite(arvValue) ? arvValue : null,
+        difference: arvDifference,
+        available: Number.isFinite(arvValue),
+        note: arvNote,
+        details: [
+          Number.isFinite(arvValue) ? { label: 'Estimated ARV', value: currency(arvValue) } : null,
+          Number.isFinite(renovationBudget)
+            ? { label: 'Renovation budget', value: currency(renovationBudget) }
+            : null,
+          Number.isFinite(arvValue)
+            ? {
+                label: 'Source',
+                value: arvSource === 'assumption' ? 'Scenario ARV assumption' : 'Exit projection',
+              }
+            : null,
+        ].filter(Boolean),
+      },
+    ];
+
+    const availableValues = factors
+      .map((factor) => (Number.isFinite(factor.impliedValue) && factor.impliedValue > 0 ? factor.impliedValue : null))
+      .filter((value) => Number.isFinite(value));
+    const valueCount = availableValues.length;
+    const minValue = valueCount > 0 ? Math.min(...availableValues) : null;
+    const maxValue = valueCount > 0 ? Math.max(...availableValues) : null;
+    const averageValue =
+      valueCount > 0 ? availableValues.reduce((total, value) => total + value, 0) / valueCount : null;
+    const averageDifference =
+      Number.isFinite(averageValue) && Number.isFinite(purchasePrice) ? averageValue - purchasePrice : null;
+
+    return {
+      purchasePrice,
+      factors,
+      minValue,
+      maxValue,
+      averageValue,
+      averageDifference,
+      valueCount,
+    };
+  }, [
+    equity,
+    equity.noiYear1,
+    equity.cap,
+    equity.grossRentYear1,
+    equity.npv,
+    equity.initialCashOutlay,
+    equity.cashIn,
+    equity.futureValue,
+    inputs.purchasePrice,
+    inputs.marketCapRate,
+    inputs.capRateBenchmark,
+    inputs.targetCapRate,
+    inputs.capRateAssumption,
+    inputs.capRateMarket,
+    inputs.marketCapRatePct,
+    inputs.capRate,
+    inputs.monthlyRent,
+    inputs.vacancyPct,
+    inputs.marketGrm,
+    inputs.grossRentMultiplier,
+    inputs.targetGrm,
+    inputs.marketGrossRentMultiplier,
+    inputs.grmBenchmark,
+    inputs.grmAssumption,
+    inputs.grossRentMultiple,
+    inputs.discountRate,
+    inputs.afterRepairValue,
+    inputs.arv,
+    inputs.estimatedArv,
+    inputs.postRenovationValue,
+    inputs.projectedArv,
+    inputs.expectedArv,
+    inputs.arvEstimate,
+    inputs.afterRenovationValue,
+    inputs.futureSaleValue,
+    inputs.renovationArv,
+    inputs.brArv,
+    inputs.exitYear,
+    inputs.renovationCost,
   ]);
   const investmentProfile = useMemo(() => {
     if (!equity) {
@@ -17766,6 +18063,138 @@ export default function App() {
                         emptyMessage="No rows match the current filters. Adjust the year range or cash flow view to see results."
                       />
                     )}
+                  </>
+                ) : null}
+              </div>
+              <div
+                className={`rounded-2xl bg-white p-3 shadow-sm ${
+                  collapsedSections.marketValue ? 'md:col-span-1' : 'md:col-span-2'
+                }`}
+              >
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleSection('marketValue')}
+                      aria-expanded={!collapsedSections.marketValue}
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-700 transition hover:bg-slate-100"
+                      aria-label={collapsedSections.marketValue ? 'Show market value summary' : 'Hide market value summary'}
+                    >
+                      {collapsedSections.marketValue ? '+' : '−'}
+                    </button>
+                    <SectionTitle
+                      label="Market value"
+                      tooltip={SECTION_DESCRIPTIONS.marketValue}
+                      className="text-sm font-semibold text-slate-700"
+                    />
+                  </div>
+                </div>
+                {!collapsedSections.marketValue ? (
+                  <>
+                    <p className="mb-3 text-[11px] text-slate-500">
+                      Triangulate a fair price by comparing income-driven, discounted cash flow, and refurbishment views of
+                      value against today&apos;s asking price.
+                    </p>
+                    {marketValueSummary && marketValueSummary.valueCount > 0 ? (
+                      <div className="mb-3 rounded-xl bg-slate-50 p-3 text-[11px] text-slate-600">
+                        {(() => {
+                          const { minValue, maxValue, averageValue, purchasePrice, averageDifference, valueCount } =
+                            marketValueSummary;
+                          const hasRange =
+                            Number.isFinite(minValue) &&
+                            Number.isFinite(maxValue) &&
+                            Math.abs(maxValue - minValue) > 1;
+                          const anchorValue = Number.isFinite(averageValue)
+                            ? averageValue
+                            : Number.isFinite(minValue)
+                            ? minValue
+                            : Number.isFinite(maxValue)
+                            ? maxValue
+                            : null;
+                          const segments = [];
+                          if (hasRange && Number.isFinite(minValue) && Number.isFinite(maxValue)) {
+                            segments.push(`Implied value range ${currency(minValue)} – ${currency(maxValue)}`);
+                          } else if (Number.isFinite(anchorValue)) {
+                            segments.push(`Implied value ${currency(anchorValue)}`);
+                          }
+                          if (Number.isFinite(purchasePrice) && Number.isFinite(averageDifference)) {
+                            segments.push(
+                              `vs purchase price ${currency(purchasePrice)} (${formatCurrencyDelta(averageDifference)})`
+                            );
+                          }
+                          const messages = [];
+                          if (segments.length > 0) {
+                            messages.push(`${segments.join('. ')}.`);
+                          }
+                          messages.push(
+                            valueCount === 1
+                              ? '1 method informed this estimate.'
+                              : `${valueCount} methods informed this estimate.`
+                          );
+                          return messages.join(' ');
+                        })()}
+                      </div>
+                    ) : (
+                      <div className="mb-3 rounded-xl border border-dashed border-slate-200 p-3 text-center text-[11px] text-slate-500">
+                        Provide income, expense, and valuation assumptions to generate market value estimates.
+                      </div>
+                    )}
+                    <div className="grid gap-3 md:grid-cols-2">
+                      {(marketValueSummary?.factors ?? []).map((factor) => {
+                        const differenceText =
+                          Number.isFinite(factor.difference) && Number.isFinite(marketValueSummary?.purchasePrice)
+                            ? `Δ vs purchase price: ${formatCurrencyDelta(factor.difference)}`
+                            : '';
+                        return (
+                          <div
+                            key={factor.key}
+                            className="flex h-full flex-col rounded-xl border border-slate-200 bg-slate-50 p-3"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <div className="text-xs font-semibold text-slate-700">{factor.label}</div>
+                                <div className="mt-1 text-[11px] text-slate-500">{factor.purpose}</div>
+                                <div className="mt-1 text-[11px] text-slate-500">
+                                  <span className="font-semibold text-slate-600">Used by:</span> {factor.usedBy}
+                                </div>
+                              </div>
+                              <div className="text-right text-sm font-semibold text-slate-800">
+                                {Number.isFinite(factor.impliedValue) ? currency(factor.impliedValue) : '—'}
+                              </div>
+                            </div>
+                            <div className="mt-3 rounded-lg bg-white p-2 text-[11px] text-slate-600">
+                              <div className="font-semibold uppercase tracking-wide text-slate-400">Formula</div>
+                              <div className="font-mono text-[11px] text-slate-700">{factor.formula}</div>
+                            </div>
+                            {factor.details.length > 0 ? (
+                              <dl className="mt-2 space-y-1 text-[11px] text-slate-600">
+                                {factor.details.map((detail) => (
+                                  <div
+                                    key={`${factor.key}-${detail.label}`}
+                                    className="flex items-center justify-between gap-2"
+                                  >
+                                    <dt className="text-slate-500">{detail.label}</dt>
+                                    <dd className="font-medium text-slate-700">{detail.value}</dd>
+                                  </div>
+                                ))}
+                              </dl>
+                            ) : null}
+                            {factor.available && differenceText ? (
+                              <div className="mt-2 text-[11px] font-semibold text-slate-700">{differenceText}</div>
+                            ) : null}
+                            {factor.available ? (
+                              factor.note ? (
+                                <div className="mt-1 text-[10px] text-slate-500">{factor.note}</div>
+                              ) : null
+                            ) : (
+                              <div className="mt-3 rounded-lg border border-dashed border-slate-300 bg-white/60 p-2 text-[11px] text-slate-500">
+                                {factor.note || 'Provide the required inputs to calculate this valuation.'}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
                   </>
                 ) : null}
               </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12638,32 +12638,13 @@ export default function App() {
       ? 'Model discounted cash flow by providing a discount rate and hold assumptions.'
       : '';
 
-    const arvCandidate = pickFirstFinite(
-      inputs.afterRepairValue,
-      inputs.arv,
-      inputs.estimatedArv,
-      inputs.postRenovationValue,
-      inputs.projectedArv,
-      inputs.expectedArv,
-      inputs.arvEstimate,
-      inputs.afterRenovationValue,
-      inputs.futureSaleValue,
-      inputs.renovationArv,
-      inputs.brArv
-    );
-    let arvSource = 'assumption';
-    let arvValue = Number.isFinite(arvCandidate) ? arvCandidate : null;
-    if (!Number.isFinite(arvValue) && Number.isFinite(equity.futureValue)) {
-      arvValue = equity.futureValue;
-      arvSource = 'projection';
-    }
+    const valueAdded = Number.isFinite(equity.bridgingValueAdded) ? equity.bridgingValueAdded : 0;
+    const arvValue = Number.isFinite(purchasePrice) ? purchasePrice + valueAdded : null;
     const arvDifference =
       Number.isFinite(arvValue) && Number.isFinite(purchasePrice) ? arvValue - purchasePrice : null;
-    const arvNote = !Number.isFinite(arvValue)
-      ? 'Add an after-repair value assumption or comparable to benchmark uplift potential.'
-      : arvSource === 'projection'
-      ? `Using year ${Math.max(1, Number(inputs.exitYear) || 1)} exit projection because no ARV assumption was provided.`
-      : '';
+    const arvNote = Number.isFinite(arvValue)
+      ? 'Calculated as purchase price plus value added.'
+      : 'Add a purchase price to estimate ARV.';
 
     const renovationBudget = Number.isFinite(inputs.renovationCost) ? inputs.renovationCost : null;
 
@@ -12747,15 +12728,13 @@ export default function App() {
         available: Number.isFinite(arvValue),
         note: arvNote,
         details: [
-          Number.isFinite(arvValue) ? { label: 'Estimated ARV', value: currency(arvValue) } : null,
+          Number.isFinite(purchasePrice) ? { label: 'Purchase price', value: currency(purchasePrice) } : null,
+          Number.isFinite(valueAdded) ? { label: 'Value added', value: currency(valueAdded) } : null,
+          Number.isFinite(arvValue)
+            ? { label: 'Estimated ARV', value: currency(arvValue) }
+            : null,
           Number.isFinite(renovationBudget)
             ? { label: 'Renovation budget', value: currency(renovationBudget) }
-            : null,
-          Number.isFinite(arvValue)
-            ? {
-                label: 'Source',
-                value: arvSource === 'assumption' ? 'Scenario ARV assumption' : 'Exit projection',
-              }
             : null,
         ].filter(Boolean),
       },
@@ -12808,18 +12787,6 @@ export default function App() {
     inputs.grmAssumption,
     inputs.grossRentMultiple,
     inputs.discountRate,
-    inputs.afterRepairValue,
-    inputs.arv,
-    inputs.estimatedArv,
-    inputs.postRenovationValue,
-    inputs.projectedArv,
-    inputs.expectedArv,
-    inputs.arvEstimate,
-    inputs.afterRenovationValue,
-    inputs.futureSaleValue,
-    inputs.renovationArv,
-    inputs.brArv,
-    inputs.exitYear,
     inputs.renovationCost,
   ]);
   const bridgingLoanSummary = useMemo(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12654,7 +12654,8 @@ export default function App() {
       ? 'Model discounted cash flow by providing a discount rate and hold assumptions.'
       : '';
 
-    const valueAdded = Number.isFinite(equity.bridgingValueAdded) ? equity.bridgingValueAdded : 0;
+    const rawValueAdded = Number(inputs.bridgingValueAdded ?? 0);
+    const valueAdded = Number.isFinite(rawValueAdded) ? rawValueAdded : 0;
     const arvValue = Number.isFinite(purchasePrice) ? purchasePrice + valueAdded : null;
     const arvDifference =
       Number.isFinite(arvValue) && Number.isFinite(purchasePrice) ? arvValue - purchasePrice : null;
@@ -12804,6 +12805,7 @@ export default function App() {
     inputs.grossRentMultiple,
     inputs.discountRate,
     inputs.renovationCost,
+    inputs.bridgingValueAdded,
   ]);
   const bridgingLoanSummary = useMemo(() => {
     if (!inputs.useBridgingLoan || !equity) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1774,6 +1774,7 @@ const DEFAULT_INPUTS = {
   bridgingLoanInterestRate: 0.008,
   bridgingLoanDepositPct: 0.25,
   bridgingValueAdded: 0,
+  bridgingCost: 0,
   bridgingInterestPaymentMode: 'monthly',
   capRateBenchmark: 0,
   grmBenchmark: 0,
@@ -4697,7 +4698,7 @@ const SECTION_DESCRIPTIONS = {
 const KEY_RATIO_TOOLTIPS = {
   cap: 'First-year net operating income divided by the purchase price.',
   rentalYield: 'First-year rent collected after vacancy divided by the purchase price.',
-  yoc: 'First-year net operating income divided by total project cost (price + closing + renovation).',
+  yoc: 'First-year net operating income divided by total project cost (price + closing + renovation + any bridge-only costs).',
   coc: 'Year 1 after-debt cash flow divided by total cash invested.',
   dscr: 'Debt service coverage ratio: Year 1 NOI divided by annual debt service.',
   mortgage: 'Estimated monthly mortgage payment for the modeled loan.',
@@ -4715,6 +4716,7 @@ const KNOWLEDGE_GROUPS = {
       'stampDuty',
       'closingCosts',
       'mortgagePackageFee',
+      'bridgingCost',
       'renovationCost',
       'bridgingLoanAmount',
       'netCashIn',
@@ -4844,6 +4846,14 @@ const KNOWLEDGE_METRICS = {
     description: 'Upfront lender or broker fee charged to arrange the mortgage.',
     calculation: 'User-entered flat fee paid at completion.',
     importance: 'Needs to be budgeted alongside closing costs because it increases cash required to draw the loan.',
+    unit: 'currency',
+  },
+  bridgingCost: {
+    label: 'Cost of bridge',
+    groups: ['cashNeeded'],
+    description: 'Legal or auction fees tied to arranging the bridge facility.',
+    calculation: 'User-entered cost that only applies while bridging finance is enabled.',
+    importance: 'Adds to upfront cash alongside the bridge deposit because it must be funded before refinancing.',
     unit: 'currency',
   },
   renovationCost: {
@@ -6428,6 +6438,9 @@ function calculateEquity(rawInputs) {
   const postBridgeValue = bridgingEnabled
     ? Math.max(0, inputs.purchasePrice + bridgingValueAdded)
     : inputs.purchasePrice;
+  const propertyValueBasis = bridgingEnabled ? postBridgeValue : inputs.purchasePrice;
+  const rawBridgingCost = Number(inputs.bridgingCost ?? 0);
+  const bridgingCost = bridgingEnabled && Number.isFinite(rawBridgingCost) ? Math.max(0, rawBridgingCost) : 0;
   const permanentDepositAmount = Math.max(0, postBridgeValue * inputs.depositPct);
   const deposit = bridgingEnabled ? bridgingDepositAmount : baseDepositAmount;
 
@@ -6453,7 +6466,7 @@ function calculateEquity(rawInputs) {
   const bridgingInterestPaymentMode =
     bridgingEnabled && inputs.bridgingInterestPaymentMode === 'roll_up' ? 'roll_up' : 'monthly';
   const bridgingAmount = bridgingEnabled ? Math.max(0, inputs.purchasePrice - bridgingDepositAmount) : 0;
-  const totalCashRequired = deposit + closing + inputs.renovationCost;
+  const totalCashRequired = deposit + closing + inputs.renovationCost + bridgingCost;
   const initialCashOutlay = totalCashRequired;
   const indexInitialInvestment = totalCashRequired;
 
@@ -6566,8 +6579,9 @@ function calculateEquity(rawInputs) {
 
   const cap = noiYear1 / inputs.purchasePrice;
   const cashIn = totalCashRequired;
-  const projectCost = inputs.purchasePrice + closing + inputs.renovationCost;
+  const projectCost = inputs.purchasePrice + closing + inputs.renovationCost + bridgingCost;
   const coc = cashIn === 0 ? 0 : cashflowYear1 / cashIn;
+  const yoc = projectCost > 0 ? noiYear1 / projectCost : 0;
   const dscr = debtServiceYear1 === 0 ? 0 : noiYear1 / debtServiceYear1;
 
   const months = Math.min(inputs.exitYear * 12, inputs.mortgageYears * 12);
@@ -6576,7 +6590,7 @@ function calculateEquity(rawInputs) {
       ? loan
       : remainingBalance({ principal: loan, annualRate: inputs.interestRate, years: inputs.mortgageYears, monthsPaid: months });
 
-  const futureValue = inputs.purchasePrice * Math.pow(1 + inputs.annualAppreciation, inputs.exitYear);
+  const futureValue = propertyValueBasis * Math.pow(1 + inputs.annualAppreciation, inputs.exitYear);
   const sellingCosts = futureValue * inputs.sellingCostsPct;
 
   const cf = [];
@@ -6611,9 +6625,8 @@ function calculateEquity(rawInputs) {
   const annualNoiValues = [];
   const annualCashflowsPreTax = [];
   const annualCashflowsAfterTax = [];
-  const initialNetEquity =
-    inputs.purchasePrice - inputs.purchasePrice * inputs.sellingCostsPct - loan;
-  const initialSaleValue = inputs.purchasePrice;
+  const initialNetEquity = propertyValueBasis - propertyValueBasis * inputs.sellingCostsPct - loan;
+  const initialSaleValue = propertyValueBasis;
   const initialSaleCosts = initialSaleValue * inputs.sellingCostsPct;
   const initialNetSaleProceeds = initialSaleValue - initialSaleCosts - loan;
   chart.push({
@@ -6622,8 +6635,8 @@ function calculateEquity(rawInputs) {
     indexFund1_5x: indexVal * 1.5,
     indexFund2x: indexVal * 2,
     indexFund4x: indexVal * 4,
-    propertyValue: inputs.purchasePrice,
-    propertyGross: inputs.purchasePrice,
+    propertyValue: propertyValueBasis,
+    propertyGross: propertyValueBasis,
     propertyNet: initialNetEquity,
     propertyNetAfterTax: initialNetEquity,
     reinvestFund: 0,
@@ -6749,7 +6762,7 @@ function calculateEquity(rawInputs) {
         ? loan
         : Math.max(0, remainingBalance({ principal: loan, annualRate: inputs.interestRate, years: inputs.mortgageYears, monthsPaid }));
 
-    const vt = inputs.purchasePrice * Math.pow(1 + inputs.annualAppreciation, y);
+    const vt = propertyValueBasis * Math.pow(1 + inputs.annualAppreciation, y);
     const saleCostsEstimate = vt * inputs.sellingCostsPct;
     const netSaleIfSold = vt - saleCostsEstimate - remainingLoanYear;
     const saleProceedsBeforeLoan = vt - saleCostsEstimate;
@@ -6784,7 +6797,7 @@ function calculateEquity(rawInputs) {
     const cumulativeCashAfterTaxNet = shouldReinvest
       ? cumulativeCashAfterTax - cumulativeReinvested
       : cumulativeCashAfterTax;
-    const propertyGrossValue = vt + cumulativeCashPreTaxNet;
+  const propertyGrossValue = vt + cumulativeCashPreTaxNet;
     const propertyNetValue = netSaleIfSold + cumulativeCashPreTaxNet + reinvestFundValue;
     const propertyNetAfterTaxValue = netSaleIfSoldAfterTax + cumulativeCashAfterTaxNet + reinvestFundValue;
 
@@ -6792,7 +6805,7 @@ function calculateEquity(rawInputs) {
     let yearCashflowForNpv = afterTaxCash;
     let realizedSaleProceeds = 0;
     if (!inputs.neverExit && y === inputs.exitYear) {
-      const fv = inputs.purchasePrice * Math.pow(1 + inputs.annualAppreciation, y);
+      const fv = propertyValueBasis * Math.pow(1 + inputs.annualAppreciation, y);
       const sell = fv * inputs.sellingCostsPct;
       const rem =
         inputs.loanType === 'interest_only'
@@ -7135,6 +7148,7 @@ function calculateEquity(rawInputs) {
     cashIn,
     initialCashOutlay,
     totalCashRequired,
+    bridgingCost,
     bridgingLoanAmount: bridgingAmount,
     bridgingLoanTermMonths,
     bridgingLoanInterestRate: bridgingMonthlyRate,
@@ -7153,7 +7167,7 @@ function calculateEquity(rawInputs) {
     totalCashInvestedDuringBridge,
     netCashAfterRefinance,
     projectCost,
-    yoc: noiYear1 / (inputs.purchasePrice + closing + inputs.renovationCost),
+    yoc,
     indexValEnd: indexVal,
     exitCumCash,
     exitCumCashAfterTax,
@@ -12378,6 +12392,7 @@ export default function App() {
     const closingCostsValue = Number(equity.otherClosing) || 0;
     const packageFeeValue = Number(equity.packageFees) || 0;
     const renovationValue = Number(inputs.renovationCost) || 0;
+    const bridgingCostValue = Number(equity.bridgingCost) || 0;
     const bridgingAmountValue = Number(equity.bridgingLoanAmount) || 0;
     const totalCashRequiredValue = Number(equity.cashIn) || 0;
     const netCashInValue = Number.isFinite(equity.initialCashOutlay)
@@ -12439,6 +12454,7 @@ export default function App() {
       closingCosts: { value: closingCostsValue, formatted: currency(closingCostsValue) },
       mortgagePackageFee: { value: packageFeeValue, formatted: currency(packageFeeValue) },
       renovationCost: { value: renovationValue, formatted: currency(renovationValue) },
+      bridgingCost: { value: bridgingCostValue, formatted: currency(bridgingCostValue) },
       bridgingLoanAmount: { value: bridgingAmountValue, formatted: currency(bridgingAmountValue) },
       netCashIn: { value: netCashInValue, formatted: currency(netCashInValue) },
       totalCashRequired: { value: totalCashRequiredValue, formatted: currency(totalCashRequiredValue) },
@@ -12805,6 +12821,7 @@ export default function App() {
     const interestTotalValue = Number(equity.bridgingInterestTotal) || interestDuringTerm + interestAtExit;
     const bridgePayoff = Number(equity.bridgingExitPayoff) || bridgingLoanAmount + interestAtExit;
     const cashRequired = Number(equity.cashIn) || 0;
+    const bridgeCost = Number(equity.bridgingCost) || 0;
     const totalInvested = Number(equity.totalCashInvestedDuringBridge) || cashRequired + interestDuringTerm;
     const valueAdded = Number(equity.bridgingValueAdded) || 0;
     const postBridgeValue = Number(equity.postBridgeValue) || Number(inputs.purchasePrice) + valueAdded;
@@ -12826,6 +12843,7 @@ export default function App() {
       interestTotalValue,
       bridgePayoff,
       cashRequired,
+      bridgeCost,
       totalInvested,
       valueAdded,
       postBridgeValue,
@@ -16253,6 +16271,7 @@ export default function App() {
                           {pctInput('bridgingLoanInterestRate', 'Bridging rate %', 0.001)}
                           {pctInput('bridgingLoanDepositPct', 'Bridge deposit %', 0.001)}
                           {moneyInput('bridgingValueAdded', 'Value added (£)', 1000)}
+                          {moneyInput('bridgingCost', 'Cost of bridge (£)', 100)}
                         </div>
                         <div className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-white p-3 text-xs text-slate-700 sm:flex-row sm:items-center sm:justify-between">
                           <div className="font-semibold">Interest handling</div>
@@ -16487,6 +16506,13 @@ export default function App() {
                   value={currency(equity.packageFees)}
                   knowledgeKey="mortgagePackageFee"
                 />
+                {inputs.useBridgingLoan ? (
+                  <Line
+                    label="Cost of bridge"
+                    value={currency(equity.bridgingCost)}
+                    knowledgeKey="bridgingCost"
+                  />
+                ) : null}
                 <Line
                   label="Renovation (upfront)"
                   value={currency(inputs.renovationCost)}
@@ -18508,6 +18534,14 @@ export default function App() {
                                   {currency(bridgingLoanSummary.cashRequired)}
                                 </dd>
                               </div>
+                              {bridgingLoanSummary.bridgeCost !== 0 ? (
+                                <div className="flex items-center justify-between gap-2">
+                                  <dt>Cost of bridge</dt>
+                                  <dd className="font-medium text-slate-800">
+                                    {currency(bridgingLoanSummary.bridgeCost)}
+                                  </dd>
+                                </div>
+                              ) : null}
                               <div className="flex items-center justify-between gap-2">
                                 <dt>Bridge loan amount</dt>
                                 <dd className="font-medium text-slate-800">
@@ -23964,6 +23998,17 @@ function PlanItemDetail({ item, onUpdate, onExitYearChange }) {
                   step={1000}
                   value={numericValue('bridgingValueAdded')}
                   onChange={(event) => handleNumberChange('bridgingValueAdded', event.target.value)}
+                  className="rounded-lg border border-slate-300 px-3 py-1.5"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-medium text-slate-600">Cost of bridge (£)</span>
+                <input
+                  type="number"
+                  min={0}
+                  step={100}
+                  value={numericValue('bridgingCost')}
+                  onChange={(event) => handleNumberChange('bridgingCost', event.target.value)}
                   className="rounded-lg border border-slate-300 px-3 py-1.5"
                 />
               </label>


### PR DESCRIPTION
## Summary
- add a helper for reusing the first valid numeric assumption when sourcing valuation inputs
- calculate cap rate, gross rent multiplier, discounted cash flow, and after-repair value indications for the subject property
- render a collapsible “Market value” report section summarising valuation ranges and per-method details ahead of the investment profile

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a694d0a8832fadc1086d1d465b5e)